### PR TITLE
execute custom user call

### DIFF
--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -9,8 +9,11 @@ pub mod transaction_status;
 pub const MIN_BLOCKS_FOR_FINALITY: u64 = 10;
 pub const TX_MULTIRESULT_NR_FIELDS: usize = 6;
 
+pub type BatchId = u64;
+pub type TxId = u64;
 pub type GasLimit = u64;
 pub type TxNonce = u64;
+
 pub type BlockNonce = u64;
 pub type SenderAddress<M> = ManagedAddress<M>;
 pub type ReceiverAddress<M> = ManagedAddress<M>;
@@ -24,7 +27,7 @@ pub type TxAsMultiValue<M> = MultiValue7<
     Option<TransferData<M>>,
 >;
 pub type PaymentsVec<M> = ManagedVec<M, EsdtTokenPayment<M>>;
-pub type TxBatchSplitInFields<M> = MultiValue2<u64, MultiValueEncoded<M, TxAsMultiValue<M>>>;
+pub type TxBatchSplitInFields<M> = MultiValue2<BatchId, MultiValueEncoded<M, TxAsMultiValue<M>>>;
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, ManagedVecItem, Clone)]
 pub struct TransferData<M: ManagedTypeApi> {

--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -23,7 +23,7 @@ pub type TxAsMultiValue<M> = MultiValue7<
     SenderAddress<M>,
     ReceiverAddress<M>,
     ManagedVec<M, EsdtTokenPayment<M>>,
-    ManagedVec<M, Option<StolenFromFrameworkEsdtTokenData<M>>>,
+    ManagedVec<M, StolenFromFrameworkEsdtTokenData<M>>,
     Option<TransferData<M>>,
 >;
 pub type PaymentsVec<M> = ManagedVec<M, EsdtTokenPayment<M>>;
@@ -56,6 +56,13 @@ pub enum StolenFromFrameworkEsdtTokenType {
     Invalid,
 }
 
+impl Default for StolenFromFrameworkEsdtTokenType {
+    #[inline]
+    fn default() -> Self {
+        Self::Fungible
+    }
+}
+
 impl From<EsdtTokenType> for StolenFromFrameworkEsdtTokenType {
     fn from(value: EsdtTokenType) -> Self {
         match value {
@@ -83,6 +90,22 @@ pub struct StolenFromFrameworkEsdtTokenData<M: ManagedTypeApi> {
     pub uris: ManagedVec<M, ManagedBuffer<M>>,
 }
 
+impl<M: ManagedTypeApi> Default for StolenFromFrameworkEsdtTokenData<M> {
+    fn default() -> Self {
+        StolenFromFrameworkEsdtTokenData {
+            token_type: StolenFromFrameworkEsdtTokenType::Fungible,
+            amount: BigUint::zero(),
+            frozen: false,
+            hash: ManagedBuffer::new(),
+            name: ManagedBuffer::new(),
+            attributes: ManagedBuffer::new(),
+            creator: ManagedAddress::zero(),
+            royalties: BigUint::zero(),
+            uris: ManagedVec::new(),
+        }
+    }
+}
+
 impl<M: ManagedTypeApi> From<EsdtTokenData<M>> for StolenFromFrameworkEsdtTokenData<M> {
     fn from(value: EsdtTokenData<M>) -> Self {
         StolenFromFrameworkEsdtTokenData {
@@ -106,7 +129,7 @@ pub struct Transaction<M: ManagedTypeApi> {
     pub from: ManagedAddress<M>,
     pub to: ManagedAddress<M>,
     pub tokens: ManagedVec<M, EsdtTokenPayment<M>>,
-    pub token_data: ManagedVec<M, Option<StolenFromFrameworkEsdtTokenData<M>>>,
+    pub token_data: ManagedVec<M, StolenFromFrameworkEsdtTokenData<M>>,
     pub opt_transfer_data: Option<TransferData<M>>,
     pub is_refund_tx: bool,
 }

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -5,7 +5,8 @@ multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
 use transaction::{
-    transaction_status::TransactionStatus, BatchId, GasLimit, Transaction, TransferData, TxId,
+    transaction_status::TransactionStatus, BatchId, GasLimit, StolenFromFrameworkEsdtTokenData,
+    Transaction, TransferData, TxId,
 };
 use tx_batch_module::FIRST_BATCH_ID;
 
@@ -184,9 +185,9 @@ pub trait EsdtSafe:
                     &payment.token_identifier,
                     payment.token_nonce,
                 );
-                all_token_data.push(Some(current_token_data.into()));
+                all_token_data.push(current_token_data.into());
             } else {
-                all_token_data.push(None);
+                all_token_data.push(StolenFromFrameworkEsdtTokenData::default());
             }
         }
 

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -4,12 +4,16 @@
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
-use transaction::{transaction_status::TransactionStatus, Transaction, TransferData};
+use transaction::{
+    transaction_status::TransactionStatus, BatchId, GasLimit, Transaction, TransferData, TxId,
+};
+use tx_batch_module::FIRST_BATCH_ID;
 
 const DEFAULT_MAX_TX_BATCH_SIZE: usize = 10;
 const DEFAULT_MAX_TX_BATCH_BLOCK_DURATION: u64 = 100; // ~10 minutes
 const MAX_TRANSFERS_PER_TX: usize = 10;
-const MAX_GAS_LIMIT: u64 = 300_000_000;
+
+const MAX_USER_TX_GAS_LIMIT: GasLimit = 300_000_000;
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem)]
 pub struct NonceAmountPair<M: ManagedTypeApi> {
@@ -28,17 +32,16 @@ pub trait EsdtSafe:
     /// In case of SC gas limits, this value is provided by the user
     /// Will be used to compute the fees for the transfer
     #[init]
-    fn init(&self, sovereign_tx_gas_limit: BigUint) {
-        self.sovereign_tx_gas_limit().set(&sovereign_tx_gas_limit);
+    fn init(&self, sovereign_tx_gas_limit: GasLimit) {
+        self.sovereign_tx_gas_limit().set(sovereign_tx_gas_limit);
 
-        self.max_tx_batch_size()
-            .set_if_empty(DEFAULT_MAX_TX_BATCH_SIZE);
+        self.max_tx_batch_size().set(DEFAULT_MAX_TX_BATCH_SIZE);
         self.max_tx_batch_block_duration()
-            .set_if_empty(DEFAULT_MAX_TX_BATCH_BLOCK_DURATION);
+            .set(DEFAULT_MAX_TX_BATCH_BLOCK_DURATION);
 
         // batch ID 0 is considered invalid
-        self.first_batch_id().set_if_empty(1);
-        self.last_batch_id().set_if_empty(1);
+        self.first_batch_id().set(FIRST_BATCH_ID);
+        self.last_batch_id().set(FIRST_BATCH_ID);
 
         self.set_paused(true);
     }
@@ -54,7 +57,7 @@ pub trait EsdtSafe:
     #[endpoint(setTransactionBatchStatus)]
     fn set_transaction_batch_status(
         &self,
-        batch_id: u64,
+        batch_id: BatchId,
         tx_statuses: MultiValueEncoded<TransactionStatus>,
     ) {
         let first_batch_id = self.first_batch_id().get();
@@ -82,7 +85,7 @@ pub trait EsdtSafe:
                     // tokens will remain locked forever in that case
                     // otherwise, the whole batch would fail
                     for token in &tx.tokens {
-                        if self.is_local_role_set(&token.token_identifier, &EsdtLocalRole::Burn) {
+                        if self.is_burn_role_set(&token) {
                             self.send().esdt_local_burn(
                                 &token.token_identifier,
                                 token.token_nonce,
@@ -164,7 +167,7 @@ pub trait EsdtSafe:
 
         if let OptionalValue::Some(transfer_data) = &opt_transfer_data {
             require!(
-                transfer_data.gas_limit <= MAX_GAS_LIMIT,
+                transfer_data.gas_limit <= MAX_USER_TX_GAS_LIMIT,
                 "Gas limit too high"
             );
         }
@@ -201,7 +204,8 @@ pub trait EsdtSafe:
             is_refund_tx: false,
         };
 
-        let batch_id = self.add_to_batch(tx);
+        let default_gas_cost = self.sovereign_tx_gas_limit().get();
+        let batch_id = self.add_to_batch(tx, default_gas_cost);
         self.create_transaction_event(batch_id, tx_nonce);
     }
 
@@ -265,24 +269,32 @@ pub trait EsdtSafe:
             });
     }
 
+    fn is_burn_role_set(&self, payment: &EsdtTokenPayment) -> bool {
+        if payment.token_nonce == 0 {
+            self.is_local_role_set(&payment.token_identifier, &EsdtLocalRole::Burn)
+        } else {
+            self.is_local_role_set(&payment.token_identifier, &EsdtLocalRole::NftBurn)
+        }
+    }
+
     // events
 
     #[event("createTransactionEvent")]
-    fn create_transaction_event(&self, #[indexed] batch_id: u64, #[indexed] tx_id: u64);
+    fn create_transaction_event(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);
 
     #[event("addRefundTransactionEvent")]
     fn add_refund_transaction_event(
         &self,
-        #[indexed] batch_id: u64,
-        #[indexed] tx_id: u64,
-        #[indexed] original_tx_id: u64,
+        #[indexed] batch_id: BatchId,
+        #[indexed] tx_id: TxId,
+        #[indexed] original_tx_id: TxId,
     );
 
     #[event("setStatusEvent")]
     fn set_status_event(
         &self,
-        #[indexed] batch_id: u64,
-        #[indexed] tx_id: u64,
+        #[indexed] batch_id: BatchId,
+        #[indexed] tx_id: TxId,
         #[indexed] tx_status: TransactionStatus,
     );
 
@@ -297,5 +309,5 @@ pub trait EsdtSafe:
 
     #[view(getSovereignTxGasLimit)]
     #[storage_mapper("sovereignTxGasLimit")]
-    fn sovereign_tx_gas_limit(&self) -> SingleValueMapper<BigUint>;
+    fn sovereign_tx_gas_limit(&self) -> SingleValueMapper<GasLimit>;
 }

--- a/multi-transfer-esdt/Cargo.toml
+++ b/multi-transfer-esdt/Cargo.toml
@@ -19,6 +19,7 @@ path = "../common/max-bridged-amount-module"
 
 [dependencies.multiversx-sc]
 version = "0.43.4"
+features = ["promises"]
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.43.4"

--- a/multi-transfer-esdt/src/lib.rs
+++ b/multi-transfer-esdt/src/lib.rs
@@ -256,7 +256,7 @@ pub trait MultiTransferEsdt:
                 None => {
                     self.send().direct_multi(&tx.to, payments.deref());
 
-                    self.transfer_performed_event(batch_id, tx.nonce);
+                    self.transfer_performed_event(batch_id, tx.nonce, tx);
                 }
             }
         }
@@ -272,7 +272,7 @@ pub trait MultiTransferEsdt:
     ) {
         match result {
             ManagedAsyncCallResult::Ok(_) => {
-                self.transfer_performed_event(batch_id, tx_nonce);
+                self.transfer_performed_event(batch_id, tx_nonce, original_tx);
             }
             ManagedAsyncCallResult::Err(_) => {
                 let tokens = original_tx.tokens.clone();
@@ -287,7 +287,12 @@ pub trait MultiTransferEsdt:
     // events
 
     #[event("transferPerformedEvent")]
-    fn transfer_performed_event(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);
+    fn transfer_performed_event(
+        &self,
+        #[indexed] batch_id: BatchId,
+        #[indexed] tx_id: TxId,
+        tx: Transaction<Self::Api>,
+    );
 
     #[event("transferFailedInvalidToken")]
     fn transfer_failed_invalid_token(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);

--- a/multi-transfer-esdt/src/lib.rs
+++ b/multi-transfer-esdt/src/lib.rs
@@ -2,13 +2,19 @@
 
 multiversx_sc::imports!();
 
+use core::ops::Deref;
+
 use transaction::{
-    PaymentsVec, StolenFromFrameworkEsdtTokenData, Transaction, TxBatchSplitInFields,
+    BatchId, GasLimit, PaymentsVec, StolenFromFrameworkEsdtTokenData, Transaction,
+    TxBatchSplitInFields, TxId, TxNonce,
 };
+use tx_batch_module::FIRST_BATCH_ID;
 
 const DEFAULT_MAX_TX_BATCH_SIZE: usize = 10;
 const DEFAULT_MAX_TX_BATCH_BLOCK_DURATION: u64 = u64::MAX;
 const NFT_AMOUNT: u32 = 1;
+
+const CALLBACK_GAS: GasLimit = 1_000_000; // Increase if not enough
 
 #[multiversx_sc::contract]
 pub trait MultiTransferEsdt:
@@ -16,14 +22,13 @@ pub trait MultiTransferEsdt:
 {
     #[init]
     fn init(&self) {
-        self.max_tx_batch_size()
-            .set_if_empty(DEFAULT_MAX_TX_BATCH_SIZE);
+        self.max_tx_batch_size().set(DEFAULT_MAX_TX_BATCH_SIZE);
         self.max_tx_batch_block_duration()
-            .set_if_empty(DEFAULT_MAX_TX_BATCH_BLOCK_DURATION);
+            .set(DEFAULT_MAX_TX_BATCH_BLOCK_DURATION);
 
         // batch ID 0 is considered invalid
-        self.first_batch_id().set_if_empty(1);
-        self.last_batch_id().set_if_empty(1);
+        self.first_batch_id().set(FIRST_BATCH_ID);
+        self.last_batch_id().set(FIRST_BATCH_ID);
     }
 
     #[endpoint]
@@ -33,11 +38,11 @@ pub trait MultiTransferEsdt:
     #[endpoint(batchTransferEsdtToken)]
     fn batch_transfer_esdt_token(
         &self,
-        batch_id: u64,
+        batch_id: BatchId,
         transfers: MultiValueEncoded<Transaction<Self::Api>>,
     ) {
-        let mut valid_payments_list = ManagedVec::new();
-        let mut valid_dest_addresses_list = ManagedVec::new();
+        let mut successful_tx_list = ManagedVec::new();
+        let mut all_tokens_to_send = ManagedVec::new();
         let mut refund_tx_list = ManagedVec::new();
 
         let own_sc_address = self.blockchain().get_sc_address();
@@ -70,15 +75,12 @@ pub trait MultiTransferEsdt:
             }
 
             let user_tokens_to_send = self.mint_tokens(tokens_to_send, sent_token_data);
+            all_tokens_to_send.push(user_tokens_to_send);
 
-            // emit event before the actual transfer so we don't have to save the tx_nonces as well
-            self.transfer_performed_event(batch_id, sov_tx.nonce);
-
-            valid_dest_addresses_list.push(sov_tx.to);
-            valid_payments_list.push(user_tokens_to_send);
+            successful_tx_list.push(sov_tx);
         }
 
-        self.distribute_payments(valid_dest_addresses_list, valid_payments_list);
+        self.distribute_payments(batch_id, successful_tx_list, all_tokens_to_send);
 
         self.add_multiple_tx_to_batch(&refund_tx_list);
     }
@@ -103,8 +105,8 @@ pub trait MultiTransferEsdt:
         &self,
         token: &EsdtTokenPayment,
         dest: &ManagedAddress,
-        batch_id: u64,
-        tx_nonce: u64,
+        batch_id: BatchId,
+        tx_nonce: TxNonce,
         sc_shard: u32,
     ) -> bool {
         if token.token_nonce == 0 {
@@ -232,29 +234,81 @@ pub trait MultiTransferEsdt:
 
     fn distribute_payments(
         &self,
-        dest_addresses: ManagedVec<ManagedAddress>,
-        payments: ManagedVec<PaymentsVec<Self::Api>>,
+        batch_id: BatchId,
+        tx_list: ManagedVec<Transaction<Self::Api>>,
+        tokens_list: ManagedVec<PaymentsVec<Self::Api>>,
     ) {
-        for (dest, user_tokens) in dest_addresses.iter().zip(payments.iter()) {
-            self.send().direct_multi(&dest, &user_tokens);
+        for (tx, payments) in tx_list.iter().zip(tokens_list.iter()) {
+            match &tx.opt_transfer_data {
+                Some(tx_data) => {
+                    let mut args = ManagedArgBuffer::new();
+                    for arg in &tx_data.args {
+                        args.push_arg(arg);
+                    }
+
+                    self.send()
+                        .contract_call::<()>(tx.to.clone(), tx_data.function.clone())
+                        .with_raw_arguments(args)
+                        .with_multi_token_transfer(payments.deref().clone())
+                        .with_gas_limit(tx_data.gas_limit)
+                        .async_call_promise()
+                        .with_extra_gas_for_callback(CALLBACK_GAS)
+                        .with_callback(self.callbacks().transfer_callback(batch_id, tx.nonce, tx))
+                        .register_promise();
+                }
+                None => {
+                    self.send().direct_multi(&tx.to, payments.deref());
+
+                    self.transfer_performed_event(batch_id, tx.nonce);
+                }
+            }
+        }
+    }
+
+    #[promises_callback]
+    fn transfer_callback(
+        &self,
+        batch_id: BatchId,
+        tx_nonce: TxNonce,
+        original_tx: Transaction<Self::Api>,
+        #[call_result] result: ManagedAsyncCallResult<IgnoreValue>,
+    ) {
+        match result {
+            ManagedAsyncCallResult::Ok(_) => {
+                self.transfer_performed_event(batch_id, tx_nonce);
+            }
+            ManagedAsyncCallResult::Err(_) => {
+                let tokens = original_tx.tokens.clone();
+                let refund_tx = self.convert_to_refund_tx(original_tx, tokens);
+                self.add_multiple_tx_to_batch(&ManagedVec::from_single_item(refund_tx));
+
+                self.transfer_failed_execution_failed(batch_id, tx_nonce);
+            }
         }
     }
 
     // events
 
     #[event("transferPerformedEvent")]
-    fn transfer_performed_event(&self, #[indexed] batch_id: u64, #[indexed] tx_id: u64);
+    fn transfer_performed_event(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);
 
     #[event("transferFailedInvalidToken")]
-    fn transfer_failed_invalid_token(&self, #[indexed] batch_id: u64, #[indexed] tx_id: u64);
+    fn transfer_failed_invalid_token(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);
 
     #[event("transferFailedFrozenDestinationAccount")]
     fn transfer_failed_frozen_destination_account(
         &self,
-        #[indexed] batch_id: u64,
-        #[indexed] tx_id: u64,
+        #[indexed] batch_id: BatchId,
+        #[indexed] tx_id: TxId,
     );
 
     #[event("transferOverMaxAmount")]
-    fn transfer_over_max_amount(&self, #[indexed] batch_id: u64, #[indexed] tx_id: u64);
+    fn transfer_over_max_amount(&self, #[indexed] batch_id: BatchId, #[indexed] tx_id: TxId);
+
+    #[event("transferFailedExecutionFailed")]
+    fn transfer_failed_execution_failed(
+        &self,
+        #[indexed] batch_id: BatchId,
+        #[indexed] tx_id: TxId,
+    );
 }

--- a/multi-transfer-esdt/wasm/Cargo.lock
+++ b/multi-transfer-esdt/wasm/Cargo.lock
@@ -32,15 +32,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bridged-tokens-wrapper"
-version = "0.0.0"
-dependencies = [
- "multiversx-sc",
- "multiversx-sc-modules",
- "transaction",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,7 +75,6 @@ dependencies = [
 name = "multi-transfer-esdt"
 version = "0.0.0"
 dependencies = [
- "bridged-tokens-wrapper",
  "max-bridged-amount-module",
  "multiversx-sc",
  "transaction",
@@ -146,15 +136,6 @@ dependencies = [
  "quote",
  "radix_trie",
  "syn",
-]
-
-[[package]]
-name = "multiversx-sc-modules"
-version = "0.43.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75dc2548fe5072cad37b5c816d2344d7cd12e8cafb1a0ff8bbf2bc1829054710"
-dependencies = [
- "multiversx-sc",
 ]
 
 [[package]]

--- a/multi-transfer-esdt/wasm/src/lib.rs
+++ b/multi-transfer-esdt/wasm/src/lib.rs
@@ -5,9 +5,10 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           15
+// Endpoints:                           13
 // Async Callback (empty):               1
-// Total number of exported functions:  17
+// Promise callbacks:                    1
+// Total number of exported functions:  16
 
 #![no_std]
 
@@ -25,8 +26,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         batchTransferEsdtToken => batch_transfer_esdt_token
         getAndClearFirstRefundBatch => get_and_clear_first_refund_batch
-        setWrappingContractAddress => set_wrapping_contract_address
-        getWrappingContractAddress => wrapping_contract_address
         setMaxTxBatchSize => set_max_tx_batch_size
         setMaxTxBatchBlockDuration => set_max_tx_batch_block_duration
         getCurrentTxBatch => get_current_tx_batch
@@ -37,6 +36,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         getLastBatchId => last_batch_id
         setMaxBridgedAmount => set_max_bridged_amount
         getMaxBridgedAmount => max_bridged_amount
+        transfer_callback => transfer_callback
     )
 }
 


### PR DESCRIPTION
- execute user custom call, using promises
- add rename types for BatchId and TxId
- use FIRST_BATCH_ID const instead of hardcoding
- account for total gas limit when creating a batch
- use `set` instead of `set_if_empty`, since we now have `upgrade` endpoint