### PR TITLE
Modified fee subtraction logic

### DIFF
--- a/fee-market/src/enable_fee.rs
+++ b/fee-market/src/enable_fee.rs
@@ -14,6 +14,7 @@ pub trait EnableFeeModule {
         self.fee_enabled().set(false);
     }
 
+    #[endpoint(isFeeEnabled)]
     fn is_fee_enabled(&self) -> bool {
         self.fee_enabled().get()
     }


### PR DESCRIPTION
Even though we do have logic that can `disableFess` or `enableFees`, the `deposit` endpoint inside `ESDTSafe` still needs to get at least 2 input tokens, 1 one for the fees and the others ones for the transfers.  