### PR TITLE
Enshrine Cleanup + Token Mapping

### DIFF
--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use codec::arrayvec::IntoIter;
+
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
@@ -51,6 +53,16 @@ impl<M: ManagedTypeApi> Operation<M> {
 
         tuple_arr
     }
+
+    pub fn map_tokens_vec_to_multi_value(&self) -> MultiValueEncoded<M, OperationEsdtPayment<M>> {
+        let mut multi_value_tokens = MultiValueEncoded::new();
+
+        for token in &self.tokens {
+            multi_value_tokens.push(token);
+        }
+
+        multi_value_tokens
+    }
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, ManagedVecItem, Clone)]
@@ -73,7 +85,6 @@ pub struct OperationTuple<M: ManagedTypeApi> {
     pub operation: Operation<M>,
 }
 
-// TODO: Implement IntoMultiValue
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, ManagedVecItem, Clone)]
 pub struct OperationEsdtPayment<M: ManagedTypeApi> {
     pub token_identifier: TokenIdentifier<M>,

--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use codec::arrayvec::IntoIter;
-
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 

--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -51,16 +51,6 @@ impl<M: ManagedTypeApi> Operation<M> {
 
         tuple_arr
     }
-
-    pub fn map_tokens_vec_to_multi_value(&self) -> MultiValueEncoded<M, OperationEsdtPayment<M>> {
-        let mut multi_value_tokens = MultiValueEncoded::new();
-
-        for token in &self.tokens {
-            multi_value_tokens.push(token);
-        }
-
-        multi_value_tokens
-    }
 }
 
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, TypeAbi, ManagedVecItem, Clone)]

--- a/enshrine-esdt-safe/src/enshrine_esdt_safe_proxy.rs
+++ b/enshrine-esdt-safe/src/enshrine_esdt_safe_proxy.rs
@@ -190,6 +190,22 @@ where
             .original_result()
     }
 
+    pub fn call_token_handler_mint_endpoint<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<transaction::OperationTuple<Env::Api>>,
+    >(
+        self,
+        hash_of_hashes: Arg0,
+        operation_tuple: Arg1,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("call_token_handler_mint_endpoint")
+            .argument(&hash_of_hashes)
+            .argument(&operation_tuple)
+            .original_result()
+    }
+
     pub fn register_new_token_id<
         Arg0: ProxyArg<MultiValueEncoded<Env::Api, TokenIdentifier<Env::Api>>>,
     >(

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -83,16 +83,15 @@ pub trait TransferTokensModule:
         operation_tuple: OperationTuple<Self::Api>,
     ) {
         let token_handler_address = self.token_handler_address().get();
-        let mut multi_value_tokens = MultiValueEncoded::new();
-
-        for token in operation_tuple.operation.tokens.iter().clone() {
-            multi_value_tokens.push(token);
-        }
 
         self.tx()
             .to(token_handler_address)
             .typed(token_handler_proxy::TokenHandlerProxy)
-            .mint_tokens(hash_of_hashes, operation_tuple, multi_value_tokens)
+            .mint_tokens(
+                hash_of_hashes,
+                operation_tuple.clone(),
+                operation_tuple.operation.map_tokens_vec_to_multi_value(),
+            )
             .callback(<Self as TransferTokensModule>::callbacks(self).save_minted_tokens())
             .async_call_and_exit();
     }

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -1,12 +1,8 @@
 use crate::{common, to_sovereign, token_handler_proxy};
-use builtin_func_names::ESDT_NFT_CREATE_FUNC_NAME;
-use header_verifier::header_verifier_proxy;
 use multiversx_sc::imports::*;
-use multiversx_sc::{api::ESDT_MULTI_TRANSFER_FUNC_NAME, codec, storage::StorageKey};
-use transaction::{GasLimit, Operation, OperationData, OperationEsdtPayment, OperationTuple};
+use multiversx_sc::storage::StorageKey;
+use transaction::{Operation, OperationData, OperationEsdtPayment, OperationTuple};
 
-const CALLBACK_GAS: GasLimit = 10_000_000; // Increase if not enough
-const TRANSACTION_GAS: GasLimit = 30_000_000;
 const DEFAULT_ISSUE_COST: u64 = 50000000000000000;
 
 #[multiversx_sc::module]
@@ -83,15 +79,13 @@ pub trait TransferTokensModule:
         operation_tuple: OperationTuple<Self::Api>,
     ) {
         let token_handler_address = self.token_handler_address().get();
+        let multi_value_tokens: MultiValueEncoded<Self::Api, OperationEsdtPayment<Self::Api>> =
+            operation_tuple.operation.tokens.clone().into();
 
         self.tx()
             .to(token_handler_address)
             .typed(token_handler_proxy::TokenHandlerProxy)
-            .mint_tokens(
-                hash_of_hashes,
-                operation_tuple.clone(),
-                operation_tuple.operation.map_tokens_vec_to_multi_value(),
-            )
+            .mint_tokens(hash_of_hashes, operation_tuple, multi_value_tokens)
             .callback(<Self as TransferTokensModule>::callbacks(self).save_minted_tokens())
             .async_call_and_exit();
     }
@@ -153,186 +147,6 @@ pub trait TransferTokensModule:
         }
 
         true
-    }
-
-    fn mint_tokens(
-        &self,
-        operation_tokens: &ManagedVec<OperationEsdtPayment<Self::Api>>,
-    ) -> ManagedVec<OperationEsdtPayment<Self::Api>> {
-        let mut output_payments = ManagedVec::new();
-        let sov_prefix = self.get_sovereign_prefix();
-
-        for operation_token in operation_tokens.iter() {
-            if !self.has_sov_prefix(&operation_token.token_identifier, &sov_prefix) {
-                output_payments.push(operation_token.clone());
-                continue;
-            }
-
-            let mut nonce = operation_token.token_nonce;
-            if nonce == 0 {
-                self.send().esdt_local_mint(
-                    &operation_token.token_identifier,
-                    operation_token.token_nonce,
-                    &operation_token.token_data.amount,
-                );
-            } else {
-                let token_data = operation_token.token_data.clone();
-                let mut arg_buffer = ManagedArgBuffer::new();
-
-                arg_buffer.push_arg(&operation_token.token_identifier);
-                arg_buffer.push_arg(token_data.amount);
-                arg_buffer.push_arg(token_data.name);
-                arg_buffer.push_arg(token_data.royalties);
-                arg_buffer.push_arg(token_data.hash);
-                arg_buffer.push_arg(token_data.attributes);
-
-                let uris = token_data.uris.clone();
-
-                if uris.is_empty() {
-                    // at least one URI is required, so we push an empty one
-                    arg_buffer.push_arg(codec::Empty);
-                } else {
-                    // The API function has the last argument as variadic,
-                    // so we top-encode each and send as separate argument
-                    for uri in &uris {
-                        arg_buffer.push_arg(uri);
-                    }
-                }
-
-                arg_buffer.push_arg(operation_token.token_nonce);
-                arg_buffer.push_arg(token_data.creator);
-
-                let output = self.send_raw().call_local_esdt_built_in_function(
-                    self.blockchain().get_gas_left(),
-                    &ManagedBuffer::from(ESDT_NFT_CREATE_FUNC_NAME),
-                    &arg_buffer,
-                );
-
-                if let Some(first_result_bytes) = output.try_get(0) {
-                    nonce = first_result_bytes.parse_as_u64().unwrap_or_default()
-                } else {
-                    nonce = 0
-                }
-            }
-
-            output_payments.push(OperationEsdtPayment {
-                token_identifier: operation_token.token_identifier,
-                token_nonce: nonce,
-                token_data: operation_token.token_data,
-            });
-        }
-
-        output_payments
-    }
-
-    fn distribute_payments(
-        &self,
-        hash_of_hashes: ManagedBuffer,
-        operation_tuple: OperationTuple<Self::Api>,
-        tokens_list: ManagedVec<OperationEsdtPayment<Self::Api>>,
-    ) {
-        let mapped_tokens: ManagedVec<Self::Api, EsdtTokenPayment<Self::Api>> =
-            tokens_list.iter().map(|token| token.into()).collect();
-
-        match &operation_tuple.operation.data.opt_transfer_data {
-            Some(transfer_data) => {
-                let mut args = ManagedArgBuffer::new();
-                for arg in &transfer_data.args {
-                    args.push_arg(arg);
-                }
-
-                self.tx()
-                    .to(&operation_tuple.operation.to)
-                    .raw_call(transfer_data.function.clone())
-                    .arguments_raw(args.clone())
-                    .multi_esdt(mapped_tokens.clone())
-                    .gas(transfer_data.gas_limit)
-                    .callback(
-                        <Self as TransferTokensModule>::callbacks(self)
-                            .execute(&hash_of_hashes, &operation_tuple),
-                    )
-                    .gas_for_callback(CALLBACK_GAS)
-                    .register_promise();
-            }
-            None => {
-                let own_address = self.blockchain().get_sc_address();
-                let args =
-                    self.get_contract_call_args(&operation_tuple.operation.to, mapped_tokens);
-
-                self.tx()
-                    .to(own_address)
-                    .raw_call(ESDT_MULTI_TRANSFER_FUNC_NAME)
-                    .arguments_raw(args)
-                    .gas(TRANSACTION_GAS)
-                    .callback(
-                        <Self as TransferTokensModule>::callbacks(self)
-                            .execute(&hash_of_hashes, &operation_tuple),
-                    )
-                    .register_promise();
-            }
-        }
-    }
-
-    fn get_contract_call_args(
-        self,
-        to: &ManagedAddress,
-        mapped_tokens: ManagedVec<EsdtTokenPayment<Self::Api>>,
-    ) -> ManagedArgBuffer<Self::Api> {
-        let mut args = ManagedArgBuffer::new();
-        args.push_arg(to);
-        args.push_arg(mapped_tokens.len());
-
-        for token in &mapped_tokens {
-            args.push_arg(token.token_identifier);
-            args.push_arg(token.token_nonce);
-            args.push_arg(token.amount);
-        }
-
-        args
-    }
-
-    #[promises_callback]
-    fn execute(
-        &self,
-        hash_of_hashes: &ManagedBuffer,
-        operation_tuple: &OperationTuple<Self::Api>,
-        #[call_result] result: ManagedAsyncCallResult<IgnoreValue>,
-    ) {
-        match result {
-            ManagedAsyncCallResult::Ok(_) => {
-                self.execute_bridge_operation_event(
-                    hash_of_hashes.clone(),
-                    operation_tuple.op_hash.clone(),
-                );
-            }
-            ManagedAsyncCallResult::Err(_) => {
-                self.burn_sovereign_tokens(&operation_tuple.operation);
-                self.emit_transfer_failed_events(hash_of_hashes, operation_tuple);
-            }
-        }
-
-        let header_verifier_address = self.header_verifier_address().get();
-
-        self.tx()
-            .to(header_verifier_address)
-            .typed(header_verifier_proxy::HeaderverifierProxy)
-            .remove_executed_hash(hash_of_hashes, &operation_tuple.op_hash)
-            .sync_call();
-    }
-
-    fn burn_sovereign_tokens(&self, operation: &Operation<Self::Api>) {
-        let sov_prefix = self.get_sovereign_prefix();
-        for token in operation.tokens.iter() {
-            if !self.has_sov_prefix(&token.token_identifier, &sov_prefix) {
-                continue;
-            }
-
-            self.send().esdt_local_burn(
-                &token.token_identifier,
-                token.token_nonce,
-                &token.token_data.amount,
-            );
-        }
     }
 
     fn emit_transfer_failed_events(

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/src/lib.rs
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           28
+// Endpoints:                           29
 // Async Callback:                       1
 // Promise callbacks:                    2
-// Total number of exported functions:  33
+// Total number of exported functions:  34
 
 #![no_std]
 
@@ -28,6 +28,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         addSigners => add_signers
         removeSigners => remove_signers
         executeBridgeOps => execute_operations
+        call_token_handler_mint_endpoint => call_token_handler_mint_endpoint
         registerNewTokenID => register_new_token_id
         setMaxTxBatchSize => set_max_tx_batch_size
         setMaxTxBatchBlockDuration => set_max_tx_batch_block_duration

--- a/enshrine-esdt-safe/wasm/src/lib.rs
+++ b/enshrine-esdt-safe/wasm/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           28
+// Endpoints:                           29
 // Async Callback:                       1
 // Promise callbacks:                    2
-// Total number of exported functions:  33
+// Total number of exported functions:  34
 
 #![no_std]
 
@@ -28,6 +28,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         addSigners => add_signers
         removeSigners => remove_signers
         executeBridgeOps => execute_operations
+        call_token_handler_mint_endpoint => call_token_handler_mint_endpoint
         registerNewTokenID => register_new_token_id
         setMaxTxBatchSize => set_max_tx_batch_size
         setMaxTxBatchBlockDuration => set_max_tx_batch_block_duration

--- a/token-handler/src/mint_tokens.rs
+++ b/token-handler/src/mint_tokens.rs
@@ -6,7 +6,7 @@ use multiversx_sc::types::{
 };
 use multiversx_sc::types::{ManagedVec, MultiValueEncoded};
 use multiversx_sc::{codec, err_msg};
-use transaction::{GasLimit, Operation, OperationData, OperationEsdtPayment, OperationTuple};
+use transaction::{GasLimit, OperationData, OperationEsdtPayment, OperationTuple};
 
 const CALLBACK_GAS: GasLimit = 10_000_000; // Increase if not enough
 const TRANSACTION_GAS: GasLimit = 30_000_000;


### PR DESCRIPTION
Removed code from Enshrine ESDT that is now used in Token Handler contract and used `into()` to map `ManagedVec` of operation tokens to `MultiValueEncoded`

