### PR TITLE
Add contracts to map

### DIFF
--- a/chain-config/src/chain_factory_proxy.rs
+++ b/chain-config/src/chain_factory_proxy.rs
@@ -235,7 +235,7 @@ pub struct ContractMapArgs<Api>
 where
     Api: ManagedTypeApi,
 {
-    pub name: ScArray,
+    pub id: ScArray,
     pub address: ManagedAddress<Api>,
 }
 

--- a/chain-config/src/chain_factory_proxy.rs
+++ b/chain-config/src/chain_factory_proxy.rs
@@ -112,6 +112,19 @@ where
             .original_result()
     }
 
+    pub fn add_contracts_to_map<
+        Arg0: ProxyArg<MultiValueEncoded<Env::Api, ContractMapArgs<Env::Api>>>,
+    >(
+        self,
+        contracts_map: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addContractsToMap")
+            .argument(&contracts_map)
+            .original_result()
+    }
+
     pub fn blacklist_sovereign_chain_sc<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(
@@ -122,6 +135,19 @@ where
             .payment(NotPayable)
             .raw_call("blacklistSovereignChainSc")
             .argument(&sc_address)
+            .original_result()
+    }
+
+    pub fn contracts_map<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        contract_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ManagedAddress<Env::Api>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getContractsMap")
+            .argument(&contract_name)
             .original_result()
     }
 
@@ -201,4 +227,14 @@ where
             .argument(&signers)
             .original_result()
     }
+}
+
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub struct ContractMapArgs<Api>
+where
+    Api: ManagedTypeApi,
+{
+    pub name: ManagedBuffer<Api>,
+    pub address: ManagedAddress<Api>,
 }

--- a/chain-config/src/chain_factory_proxy.rs
+++ b/chain-config/src/chain_factory_proxy.rs
@@ -139,7 +139,7 @@ where
     }
 
     pub fn contracts_map<
-        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg0: ProxyArg<ScArray>,
     >(
         self,
         contract_name: Arg0,
@@ -235,6 +235,18 @@ pub struct ContractMapArgs<Api>
 where
     Api: ManagedTypeApi,
 {
-    pub name: ManagedBuffer<Api>,
+    pub name: ScArray,
     pub address: ManagedAddress<Api>,
+}
+
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub enum ScArray {
+    None,
+    ChainFactory,
+    Controller,
+    SovereignHeaderVerifier,
+    SovereignCrossChainOperation,
+    ChainConfig,
+    Slashing,
 }

--- a/chain-config/src/chain_factory_proxy.rs
+++ b/chain-config/src/chain_factory_proxy.rs
@@ -242,7 +242,6 @@ where
 #[type_abi]
 #[derive(TopEncode, TopDecode)]
 pub enum ScArray {
-    None,
     ChainFactory,
     Controller,
     SovereignHeaderVerifier,

--- a/chain-factory/src/chain_factory_proxy.rs
+++ b/chain-factory/src/chain_factory_proxy.rs
@@ -235,7 +235,7 @@ pub struct ContractMapArgs<Api>
 where
     Api: ManagedTypeApi,
 {
-    pub name: ScArray,
+    pub id: ScArray,
     pub address: ManagedAddress<Api>,
 }
 

--- a/chain-factory/src/chain_factory_proxy.rs
+++ b/chain-factory/src/chain_factory_proxy.rs
@@ -112,6 +112,19 @@ where
             .original_result()
     }
 
+    pub fn add_contracts_to_map<
+        Arg0: ProxyArg<MultiValueEncoded<Env::Api, ContractMapArgs<Env::Api>>>,
+    >(
+        self,
+        contracts_map: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("addContractsToMap")
+            .argument(&contracts_map)
+            .original_result()
+    }
+
     pub fn blacklist_sovereign_chain_sc<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(
@@ -122,6 +135,19 @@ where
             .payment(NotPayable)
             .raw_call("blacklistSovereignChainSc")
             .argument(&sc_address)
+            .original_result()
+    }
+
+    pub fn contracts_map<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+    >(
+        self,
+        contract_name: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ManagedAddress<Env::Api>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getContractsMap")
+            .argument(&contract_name)
             .original_result()
     }
 
@@ -201,4 +227,14 @@ where
             .argument(&signers)
             .original_result()
     }
+}
+
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub struct ContractMapArgs<Api>
+where
+    Api: ManagedTypeApi,
+{
+    pub name: ManagedBuffer<Api>,
+    pub address: ManagedAddress<Api>,
 }

--- a/chain-factory/src/chain_factory_proxy.rs
+++ b/chain-factory/src/chain_factory_proxy.rs
@@ -139,7 +139,7 @@ where
     }
 
     pub fn contracts_map<
-        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg0: ProxyArg<ScArray>,
     >(
         self,
         contract_name: Arg0,
@@ -235,6 +235,18 @@ pub struct ContractMapArgs<Api>
 where
     Api: ManagedTypeApi,
 {
-    pub name: ManagedBuffer<Api>,
+    pub name: ScArray,
     pub address: ManagedAddress<Api>,
+}
+
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub enum ScArray {
+    None,
+    ChainFactory,
+    Controller,
+    SovereignHeaderVerifier,
+    SovereignCrossChainOperation,
+    ChainConfig,
+    Slashing,
 }

--- a/chain-factory/src/chain_factory_proxy.rs
+++ b/chain-factory/src/chain_factory_proxy.rs
@@ -242,7 +242,6 @@ where
 #[type_abi]
 #[derive(TopEncode, TopDecode)]
 pub enum ScArray {
-    None,
     ChainFactory,
     Controller,
     SovereignHeaderVerifier,

--- a/chain-factory/src/factory.rs
+++ b/chain-factory/src/factory.rs
@@ -13,7 +13,6 @@ struct ContractMapArgs<M: ManagedTypeApi> {
     TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, Clone, ManagedVecItem, PartialEq,
 )]
 pub enum ScArray {
-    None,
     ChainFactory,
     Controller,
     SovereignHeaderVerifier,
@@ -62,11 +61,7 @@ pub trait FactoryModule {
         &self,
         contracts_map: MultiValueEncoded<Self::Api, ContractMapArgs<Self::Api>>,
     ) {
-        require!(!contracts_map.is_empty(), "Given contracts map is empty");
-
         for contract in contracts_map {
-            require!(contract.id != ScArray::None, "Contract name cannot be None");
-
             self.contracts_map(contract.id).set(contract.address);
         }
     }

--- a/chain-factory/src/factory.rs
+++ b/chain-factory/src/factory.rs
@@ -5,7 +5,7 @@ multiversx_sc::imports!();
 
 #[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem)]
 struct ContractMapArgs<M: ManagedTypeApi> {
-    name: ScArray,
+    id: ScArray,
     address: ManagedAddress<M>,
 }
 
@@ -65,12 +65,9 @@ pub trait FactoryModule {
         require!(!contracts_map.is_empty(), "Given contracts map is empty");
 
         for contract in contracts_map {
-            require!(
-                contract.name != ScArray::None,
-                "Contract name cannot be None"
-            );
+            require!(contract.id != ScArray::None, "Contract name cannot be None");
 
-            self.contracts_map(contract.name).set(contract.address);
+            self.contracts_map(contract.id).set(contract.address);
         }
     }
 

--- a/chain-factory/src/factory.rs
+++ b/chain-factory/src/factory.rs
@@ -59,6 +59,7 @@ pub trait FactoryModule {
         contracts_map: MultiValueEncoded<Self::Api, ContractMapArgs<Self::Api>>,
     ) {
         require!(!contracts_map.is_empty(), "Given contracts map is empty");
+
         let mapped_array: ManagedVec<ManagedBuffer> = SC_ARRAY
             .into_iter()
             .map(|sc| ManagedBuffer::from(*sc))

--- a/chain-factory/wasm-chain-factory-full/src/lib.rs
+++ b/chain-factory/wasm-chain-factory-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            8
+// Endpoints:                           10
 // Async Callback (empty):               1
-// Total number of exported functions:  11
+// Total number of exported functions:  13
 
 #![no_std]
 
@@ -21,7 +21,9 @@ multiversx_sc_wasm_adapter::endpoints! {
         init => init
         upgrade => upgrade
         deploySovereignChainConfigContract => deploy_sovereign_chain_config_contract
+        addContractsToMap => add_contracts_to_map
         blacklistSovereignChainSc => blacklist_sovereign_chain_sc
+        getContractsMap => contracts_map
         getDeployCost => deploy_cost
         slash => slash
         distributeSlashed => distribute_slashed

--- a/chain-factory/wasm/src/lib.rs
+++ b/chain-factory/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            8
+// Endpoints:                           10
 // Async Callback (empty):               1
-// Total number of exported functions:  11
+// Total number of exported functions:  13
 
 #![no_std]
 
@@ -21,7 +21,9 @@ multiversx_sc_wasm_adapter::endpoints! {
         init => init
         upgrade => upgrade
         deploySovereignChainConfigContract => deploy_sovereign_chain_config_contract
+        addContractsToMap => add_contracts_to_map
         blacklistSovereignChainSc => blacklist_sovereign_chain_sc
+        getContractsMap => contracts_map
         getDeployCost => deploy_cost
         slash => slash
         distributeSlashed => distribute_slashed


### PR DESCRIPTION
Endpoint: addContractsToMap@list<contractName, address>
The initial setup of the contract will be made by a user account and finally it will give the ownership to the controller. On initial setup we will add the map of address to base contract and base contracts to address. This is needed in order to use deployContractFromSource/upgradeContractFromSource. The list of needed contracts are: chainFactorySC, controllerSC, sovereignHeaderVerifierSC, sovereignCrossChainOperationSC, chainConfigSC, slashingSC. 