### PR TITLE
`finishSetup` endpoint + Config mappers

### DIFF
--- a/chain-config/src/chain_config_proxy.rs
+++ b/chain-config/src/chain_config_proxy.rs
@@ -97,6 +97,15 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn finish_setup(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("finishSetup")
+            .original_result()
+    }
+
     pub fn deploy_bridge<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<u32>,
@@ -113,6 +122,24 @@ where
             .argument(&code)
             .argument(&min_valid_signers)
             .argument(&signers)
+            .original_result()
+    }
+
+    pub fn min_bls_keys(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, usize> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getMinBlsKeys")
+            .original_result()
+    }
+
+    pub fn max_bls_keys(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, usize> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getMaxBlsKeys")
             .original_result()
     }
 
@@ -162,6 +189,60 @@ where
             .payment(NotPayable)
             .raw_call("wasPreviouslySlashed")
             .argument(&validator)
+            .original_result()
+    }
+
+    pub fn address_whitelist(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAddressWhitelist")
+            .original_result()
+    }
+
+    pub fn address_blacklist(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getAddressBlacklist")
+            .original_result()
+    }
+
+    pub fn bls_whitelist(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getBlsWhitelist")
+            .original_result()
+    }
+
+    pub fn bls_blacklist(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, MultiValueEncoded<Env::Api, ManagedAddress<Env::Api>>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getBlsBlacklist")
+            .original_result()
+    }
+
+    pub fn native_token_id(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, TokenIdentifier<Env::Api>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getNativeTokenId")
+            .original_result()
+    }
+
+    pub fn header_verifier_address(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ManagedAddress<Env::Api>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getHeaderVerifierAddress")
             .original_result()
     }
 

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -54,7 +54,7 @@ pub trait ChainConfigContract:
         let header_verifier_address = self.header_verifier_address().get();
 
         require!(
-            caller != header_verifier_address,
+            self.admins().contains(&header_verifier_address),
             "The Header Verifier SC is already the admin"
         );
 

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use __wasm__endpoints__::header_verifier_address;
-use multiversx_sc_modules::only_admin;
 use validator_rules::TokenIdAmountPair;
 
 multiversx_sc::imports!();

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use __wasm__endpoints__::header_verifier_address;
+use multiversx_sc_modules::only_admin;
 use validator_rules::TokenIdAmountPair;
 
 multiversx_sc::imports!();
@@ -46,4 +48,19 @@ pub trait ChainConfigContract:
 
     #[upgrade]
     fn upgrade(&self) {}
+
+    #[only_admin]
+    #[endpoint(finishSetup)]
+    fn finish_setup(&self) {
+        let caller = self.blockchain().get_caller();
+        let header_verifier_address = self.header_verifier_address().get();
+
+        require!(
+            caller != header_verifier_address,
+            "The Header Verifier SC is already the admin"
+        );
+
+        self.admins().swap_remove(&caller);
+        self.add_admin(header_verifier_address);
+    }
 }

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -59,4 +59,8 @@ pub trait ValidatorRulesModule {
     #[view(getBlsBlacklist)]
     #[storage_mapper("blsBlacklist")]
     fn bls_blacklist(&self) -> UnorderedSetMapper<ManagedAddress<Self::Api>>;
+
+    #[view(getNativeTokenId)]
+    #[storage_mapper("nativeTokenId")]
+    fn native_token_id(&self) -> SingleValueMapper<TokenIdentifier<Self::Api>>;
 }

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -12,6 +12,14 @@ pub struct TokenIdAmountPair<M: ManagedTypeApi> {
 
 #[multiversx_sc::module]
 pub trait ValidatorRulesModule {
+    #[view(getMinBlsKeys)]
+    #[storage_mapper("minBlsKeys")]
+    fn min_bls_keys(&self) -> SingleValueMapper<usize>;
+
+    #[view(getMaxBlsKeys)]
+    #[storage_mapper("maxBlsKeys")]
+    fn max_bls_keys(&self) -> SingleValueMapper<usize>;
+
     #[view(getMinValidators)]
     #[storage_mapper("minValidators")]
     fn min_validators(&self) -> SingleValueMapper<usize>;

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -63,4 +63,8 @@ pub trait ValidatorRulesModule {
     #[view(getNativeTokenId)]
     #[storage_mapper("nativeTokenId")]
     fn native_token_id(&self) -> SingleValueMapper<TokenIdentifier<Self::Api>>;
+
+    #[view(getHeaderVerifierAddress)]
+    #[storage_mapper("headerVerifierAddress")]
+    fn header_verifier_address(&self) -> SingleValueMapper<ManagedAddress<Self::Api>>;
 }

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -43,4 +43,20 @@ pub trait ValidatorRulesModule {
     #[view(wasPreviouslySlashed)]
     #[storage_mapper("wasPreviouslySlashed")]
     fn was_previously_slashed(&self, validator: &ManagedAddress) -> SingleValueMapper<bool>;
+
+    #[view(getAddressWhitelist)]
+    #[storage_mapper("addressWhitelist")]
+    fn address_whitelist(&self) -> UnorderedSetMapper<ManagedAddress<Self::Api>>;
+
+    #[view(getAddressBlacklist)]
+    #[storage_mapper("addressBlacklist")]
+    fn address_blacklist(&self) -> UnorderedSetMapper<ManagedAddress<Self::Api>>;
+
+    #[view(getBlsWhitelist)]
+    #[storage_mapper("blsWhitelist")]
+    fn bls_whitelist(&self) -> UnorderedSetMapper<ManagedAddress<Self::Api>>;
+
+    #[view(getBlsBlacklist)]
+    #[storage_mapper("blsBlacklist")]
+    fn bls_blacklist(&self) -> UnorderedSetMapper<ManagedAddress<Self::Api>>;
 }

--- a/chain-config/wasm-chain-config-full/src/lib.rs
+++ b/chain-config/wasm-chain-config-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           10
+// Endpoints:                           19
 // Async Callback (empty):               1
-// Total number of exported functions:  13
+// Total number of exported functions:  22
 
 #![no_std]
 
@@ -20,12 +20,21 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        finishSetup => finish_setup
         deployBridge => deploy_bridge
+        getMinBlsKeys => min_bls_keys
+        getMaxBlsKeys => max_bls_keys
         getMinValidators => min_validators
         getMaxValidators => max_validators
         getMinStake => min_stake
         getAdditionalStakeRequired => additional_stake_required
         wasPreviouslySlashed => was_previously_slashed
+        getAddressWhitelist => address_whitelist
+        getAddressBlacklist => address_blacklist
+        getBlsWhitelist => bls_whitelist
+        getBlsBlacklist => bls_blacklist
+        getNativeTokenId => native_token_id
+        getHeaderVerifierAddress => header_verifier_address
         isAdmin => is_admin
         addAdmin => add_admin
         removeAdmin => remove_admin

--- a/chain-config/wasm/src/lib.rs
+++ b/chain-config/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           10
+// Endpoints:                           19
 // Async Callback (empty):               1
-// Total number of exported functions:  13
+// Total number of exported functions:  22
 
 #![no_std]
 
@@ -20,12 +20,21 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        finishSetup => finish_setup
         deployBridge => deploy_bridge
+        getMinBlsKeys => min_bls_keys
+        getMaxBlsKeys => max_bls_keys
         getMinValidators => min_validators
         getMaxValidators => max_validators
         getMinStake => min_stake
         getAdditionalStakeRequired => additional_stake_required
         wasPreviouslySlashed => was_previously_slashed
+        getAddressWhitelist => address_whitelist
+        getAddressBlacklist => address_blacklist
+        getBlsWhitelist => bls_whitelist
+        getBlsBlacklist => bls_blacklist
+        getNativeTokenId => native_token_id
+        getHeaderVerifierAddress => header_verifier_address
         isAdmin => is_admin
         addAdmin => add_admin
         removeAdmin => remove_admin


### PR DESCRIPTION
Endpoint: finishSetup - this will seal the setup and change the admin wallet. Can be called by the current admin wallet only.
Also added mappers for config rules that will be used for Sovereign Creation