### PR TITLE
Modified storage logic for sovereign history

### DIFF
--- a/sovereign-forge/src/common/storage.rs
+++ b/sovereign-forge/src/common/storage.rs
@@ -1,6 +1,6 @@
 use multiversx_sc::imports::{SingleValueMapper, UnorderedSetMapper};
 
-use super::utils::ChainContractsMap;
+use super::utils::ContractInfo;
 
 #[multiversx_sc::module]
 pub trait StorageModule {
@@ -8,7 +8,13 @@ pub trait StorageModule {
     fn sovereigns_mapper(
         &self,
         sovereign_creator: &ManagedAddress,
-    ) -> SingleValueMapper<ChainContractsMap<Self::Api>>;
+    ) -> SingleValueMapper<ManagedBuffer>;
+
+    #[storage_mapper("sovereignDeployedContracts")]
+    fn sovereign_deployed_contracts(
+        &self,
+        chain_id: &ManagedBuffer,
+    ) -> UnorderedSetMapper<ContractInfo<Self::Api>>;
 
     #[view(getChainFactoryAddress)]
     #[storage_mapper("chainFactories")]

--- a/sovereign-forge/src/common/utils.rs
+++ b/sovereign-forge/src/common/utils.rs
@@ -4,7 +4,7 @@ use multiversx_sc::{
     derive::{type_abi, ManagedVecItem},
     proxy_imports::{NestedDecode, NestedEncode, TopDecode, TopEncode},
     require,
-    types::{ManagedAddress, ManagedBuffer, ManagedVec},
+    types::ManagedAddress,
 };
 
 const CHARSET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
@@ -21,22 +21,6 @@ pub struct ContractInfo<M: ManagedTypeApi> {
 impl<M: ManagedTypeApi> ContractInfo<M> {
     pub fn new(id: ScArray, address: ManagedAddress<M>) -> Self {
         ContractInfo { id, address }
-    }
-}
-
-#[type_abi]
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem)]
-pub struct ChainContractsMap<M: ManagedTypeApi> {
-    pub chain_id: ManagedBuffer<M>,
-    pub contracts_info: ManagedVec<M, ContractInfo<M>>,
-}
-
-impl<M: ManagedTypeApi> ChainContractsMap<M> {
-    pub fn new(chain_id: ManagedBuffer<M>, contracts_info: ManagedVec<M, ContractInfo<M>>) -> Self {
-        ChainContractsMap {
-            chain_id,
-            contracts_info,
-        }
     }
 }
 

--- a/sovereign-forge/src/phases.rs
+++ b/sovereign-forge/src/phases.rs
@@ -1,18 +1,16 @@
+use crate::err_msg;
 use core::ops::Deref;
 use proxies::chain_factory_proxy::ChainFactoryContractProxy;
 use transaction::StakeMultiArg;
 
 use multiversx_sc::{
     require,
-    types::{ManagedVec, MultiValueEncoded, ReturnsResult},
+    types::{MultiValueEncoded, ReturnsResult},
 };
 
-use crate::{
-    common::{
-        self,
-        utils::{ChainContractsMap, ContractInfo, ScArray},
-    },
-    err_msg,
+use crate::common::{
+    self,
+    utils::{ContractInfo, ScArray},
 };
 
 const NUMBER_OF_SHARDS: u32 = 3;
@@ -89,12 +87,9 @@ pub trait PhasesModule:
         let chain_factory_contract_info =
             ContractInfo::new(ScArray::ChainConfig, chain_config_address);
 
-        let mut contracts_info = ManagedVec::new();
-        contracts_info.push(chain_factory_contract_info);
-
-        let chain_contracts_map = ChainContractsMap::new(chain_id, contracts_info);
-
-        sovereigns_mapper.set(chain_contracts_map);
+        self.sovereign_deployed_contracts(&chain_id)
+            .insert(chain_factory_contract_info);
+        sovereigns_mapper.set(chain_id);
     }
 
     #[endpoint(deployPhaseTwo)]


### PR DESCRIPTION
The problem before was that it was inefficient to modify the list of already deployed contracts since you had to create and register a new instance of the `ChainContractsMap` struct, with the new logic its easier to insert, check any existing contract since the new storage mapper is an `UnorderdedSetMapper`