### PR TITLE
Operation register with setup phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enshrine-esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "hex",

--- a/enshrine-esdt-safe/Cargo.toml
+++ b/enshrine-esdt-safe/Cargo.toml
@@ -38,6 +38,9 @@ path = "../header-verifier"
 [dependencies.token-handler]
 path = "../token-handler"
 
+[dependencies.chain-config]
+path = "../chain-config"
+
 [dependencies.multiversx-sc]
 version = "=0.56.0"
 

--- a/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_test.rs
+++ b/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_test.rs
@@ -9,7 +9,8 @@ use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{imports::MxscPath, ScenarioWorld};
 use multiversx_sc_scenario::{managed_address, ReturnsHandledOrError, ScenarioTxRun};
 use operation::aliases::{GasLimit, OptionalTransferData, PaymentsVec};
-use operation::{BridgeConfig, Operation, OperationData, OperationEsdtPayment};
+use operation::{BridgeConfig, Operation, OperationData, OperationEsdtPayment, SovereignConfig};
+use proxies::chain_config_proxy::ChainConfigContractProxy;
 use proxies::enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy;
 use proxies::fee_market_proxy::{FeeMarketProxy, FeeStruct, FeeType};
 use proxies::header_verifier_proxy::HeaderverifierProxy;
@@ -35,6 +36,8 @@ const FEE_MARKET_ADDRESS: TestSCAddress = TestSCAddress::new("fee-market");
 const FEE_MARKET_CODE_PATH: MxscPath = MxscPath::new("../fee-market/output/fee-market.mxsc.json");
 
 const CHAIN_CONFIG_ADDRESS: TestSCAddress = TestSCAddress::new("chain-config");
+const CHAIN_CONFIG_CODE_PATH: MxscPath =
+    MxscPath::new("../chain-config/output/chain-config.mxsc.json");
 
 const USER_ADDRESS: TestAddress = TestAddress::new("user");
 const INSUFFICIENT_WEGLD_ADDRESS: TestAddress = TestAddress::new("insufficient_wegld");
@@ -56,6 +59,7 @@ fn world() -> ScenarioWorld {
     blockchain.register_contract(HEADER_VERIFIER_CODE_PATH, header_verifier::ContractBuilder);
     blockchain.register_contract(TOKEN_HANDLER_CODE_PATH, token_handler::ContractBuilder);
     blockchain.register_contract(FEE_MARKET_CODE_PATH, fee_market::ContractBuilder);
+    blockchain.register_contract(CHAIN_CONFIG_CODE_PATH, chain_config::ContractBuilder);
 
     blockchain
 }
@@ -188,6 +192,32 @@ impl EnshrineTestState {
         self
     }
 
+    fn deploy_chain_config(&mut self) -> &mut Self {
+        self.world
+            .tx()
+            .from(ENSHRINE_ESDT_OWNER_ADDRESS)
+            .typed(ChainConfigContractProxy)
+            .init(
+                SovereignConfig::new(0, 2, BigUint::default(), None),
+                HEADER_VERIFIER_ADDRESS,
+            )
+            .code(CHAIN_CONFIG_CODE_PATH)
+            .new_address(CHAIN_CONFIG_ADDRESS)
+            .run();
+
+        self
+    }
+
+    fn complete_header_verifier_setup_phase(&mut self) {
+        self.world
+            .tx()
+            .from(ENSHRINE_ESDT_OWNER_ADDRESS)
+            .to(HEADER_VERIFIER_ADDRESS)
+            .typed(HeaderverifierProxy)
+            .complete_setup_phase()
+            .run();
+    }
+
     fn propose_setup_contracts(
         &mut self,
         is_sovereign_chain: bool,
@@ -201,6 +231,8 @@ impl EnshrineTestState {
             opt_config,
         );
         self.deploy_header_verifier_contract();
+        self.deploy_chain_config();
+        self.complete_header_verifier_setup_phase();
         self.deploy_token_handler_contract();
         self.deploy_fee_market_contract(fee_struct.cloned());
 

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enshrine-esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enshrine-esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/enshrine-esdt-safe/wasm/Cargo.lock
+++ b/enshrine-esdt-safe/wasm/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enshrine-esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/esdt-safe/Cargo.toml
+++ b/esdt-safe/Cargo.toml
@@ -35,6 +35,9 @@ path = "../fee-market"
 [dependencies.header-verifier]
 path = "../header-verifier"
 
+[dependencies.chain-config]
+path = "../chain-config"
+
 [dependencies.multiversx-sc]
 version = "=0.56.0"
 

--- a/esdt-safe/tests/bridge_blackbox_tests.rs
+++ b/esdt-safe/tests/bridge_blackbox_tests.rs
@@ -397,7 +397,6 @@ fn test_main_to_sov_egld_deposit_nothing_to_transfer() {
     let err_message = "Nothing to transfer";
 
     state.deploy_bridge_contract(false);
-
     state.propose_egld_deposit_and_expect_err(err_message);
 }
 
@@ -406,7 +405,6 @@ fn test_main_to_sov_deposit_ok() {
     let mut state = BridgeTestState::new();
 
     state.deploy_bridge_contract(false);
-
     state.propose_esdt_deposit();
 }
 
@@ -416,13 +414,9 @@ fn test_execute_operation_not_registered() {
     let err_message = "The current operation is not registered";
 
     state.deploy_bridge_contract(false);
-
     state.deploy_header_verifier_contract();
-
     state.propose_set_header_verifier_address();
-
     state.propose_set_esdt_safe_address();
-
     state.propose_execute_operation_and_expect_err(err_message);
 }
 

--- a/esdt-safe/tests/bridge_blackbox_tests.rs
+++ b/esdt-safe/tests/bridge_blackbox_tests.rs
@@ -11,7 +11,8 @@ use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{
     api::StaticApi, imports::MxscPath, ExpectError, ScenarioTxRun, ScenarioWorld,
 };
-use operation::{Operation, OperationData, OperationEsdtPayment};
+use operation::{Operation, OperationData, OperationEsdtPayment, SovereignConfig};
+use proxies::chain_config_proxy::ChainConfigContractProxy;
 use proxies::esdt_safe_proxy::EsdtSafeProxy;
 use proxies::fee_market_proxy::{FeeMarketProxy, FeeStruct, FeeType};
 use proxies::header_verifier_proxy::HeaderverifierProxy;
@@ -28,6 +29,8 @@ const HEADER_VERIFIER_CODE_PATH: MxscPath =
     MxscPath::new("../header-verifier/output/header-verifier.mxsc.json");
 
 const CHAIN_CONFIG_ADDRESS: TestSCAddress = TestSCAddress::new("chain-config");
+const CHAIN_CONFIG_CODE_PATH: MxscPath =
+    MxscPath::new("../chain-config/output/chain-config.mxsc.json");
 
 const USER_ADDRESS: TestAddress = TestAddress::new("user");
 const RECEIVER_ADDRESS: TestAddress = TestAddress::new("receiver");
@@ -44,6 +47,7 @@ fn world() -> ScenarioWorld {
     blockchain.register_contract(BRIDGE_CODE_PATH, esdt_safe::ContractBuilder);
     blockchain.register_contract(FEE_MARKET_CODE_PATH, fee_market::ContractBuilder);
     blockchain.register_contract(HEADER_VERIFIER_CODE_PATH, header_verifier::ContractBuilder);
+    blockchain.register_contract(CHAIN_CONFIG_CODE_PATH, chain_config::ContractBuilder);
 
     blockchain
 }
@@ -105,6 +109,32 @@ impl BridgeTestState {
             .run();
 
         self
+    }
+
+    fn deploy_chain_config(&mut self) -> &mut Self {
+        self.world
+            .tx()
+            .from(BRIDGE_OWNER_ADDRESS)
+            .typed(ChainConfigContractProxy)
+            .init(
+                SovereignConfig::new(0, 2, BigUint::default(), None),
+                HEADER_VERIFIER_ADDRESS,
+            )
+            .code(CHAIN_CONFIG_CODE_PATH)
+            .new_address(CHAIN_CONFIG_ADDRESS)
+            .run();
+
+        self
+    }
+
+    fn complete_header_verifier_setup_phase(&mut self) {
+        self.world
+            .tx()
+            .from(BRIDGE_OWNER_ADDRESS)
+            .to(HEADER_VERIFIER_ADDRESS)
+            .typed(HeaderverifierProxy)
+            .complete_setup_phase()
+            .run();
     }
 
     fn deploy_header_verifier_contract(&mut self) -> &mut Self {
@@ -401,11 +431,10 @@ fn test_register_operation() {
     let mut state = BridgeTestState::new();
 
     state.deploy_bridge_contract(false);
-
+    state.deploy_chain_config();
     state.deploy_header_verifier_contract();
-
+    state.complete_header_verifier_setup_phase();
     state.propose_set_header_verifier_address();
-
     state.propose_register_operation();
 }
 
@@ -414,14 +443,11 @@ fn test_execute_operation() {
     let mut state = BridgeTestState::new();
 
     state.deploy_bridge_contract(false);
-
+    state.deploy_chain_config();
     state.deploy_header_verifier_contract();
-
+    state.complete_header_verifier_setup_phase();
     state.propose_set_header_verifier_address();
-
     state.propose_set_esdt_safe_address();
-
     state.propose_register_operation();
-
     state.propose_execute_operation();
 }

--- a/esdt-safe/wasm-esdt-safe-full/Cargo.lock
+++ b/esdt-safe/wasm-esdt-safe-full/Cargo.lock
@@ -41,6 +41,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/esdt-safe/wasm-esdt-safe-view/Cargo.lock
+++ b/esdt-safe/wasm-esdt-safe-view/Cargo.lock
@@ -41,6 +41,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/esdt-safe/wasm/Cargo.lock
+++ b/esdt-safe/wasm/Cargo.lock
@@ -41,6 +41,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -37,7 +37,7 @@ pub trait Headerverifier: setup_phase::SetupPhaseModule {
     ) {
         require!(
             self.is_setup_phase_complete(),
-            "The setup phase must completed"
+            "The setup phase must be completed"
         );
 
         let mut hash_of_hashes_history_mapper = self.hash_of_hashes_history();

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -35,6 +35,11 @@ pub trait Headerverifier: setup_phase::SetupPhaseModule {
         bridge_operations_hash: ManagedBuffer,
         operations_hashes: MultiValueEncoded<ManagedBuffer>,
     ) {
+        require!(
+            self.is_setup_phase_complete(),
+            "The setup phase must completed"
+        );
+
         let mut hash_of_hashes_history_mapper = self.hash_of_hashes_history();
 
         require!(

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -129,11 +129,6 @@ pub trait Headerverifier: setup_phase::SetupPhaseModule {
             return;
         }
 
-        require!(
-            !self.chain_config_address().is_empty(),
-            "The Chain-Config address is not set"
-        );
-
         self.check_validator_range(self.bls_pub_keys().len() as u64);
 
         // TODO:

--- a/header-verifier/tests/header_verifier_blackbox_test.rs
+++ b/header-verifier/tests/header_verifier_blackbox_test.rs
@@ -274,14 +274,18 @@ fn test_deploy() {
 
     state.deploy_header_verifier_contract(CHAIN_CONFIG_ADDRESS);
 }
-//
-// #[test]
-// fn test_setup_phase() {
-//     let mut state = HeaderVerifierTestState::new();
-//
-//     state.deploy_header_verifier_contract(CHAIN_CONFIG_ADDRESS);
-//     state.complete_setup_phase(None);
-// }
+
+#[test]
+fn test_setup_phase() {
+    let mut state = HeaderVerifierTestState::new();
+
+    state.deploy_header_verifier_contract(CHAIN_CONFIG_ADDRESS);
+    state.deploy_chain_config(
+        &SovereignConfig::new(0, 2, BigUint::default(), None),
+        HEADER_VERIFIER_ADDRESS,
+    );
+    state.complete_setup_phase(None);
+}
 
 #[test]
 fn test_register_esdt_address() {
@@ -292,7 +296,6 @@ fn test_register_esdt_address() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -316,7 +319,6 @@ fn test_register_bridge_operation() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -362,7 +364,6 @@ fn test_remove_executed_hash_caller_not_esdt_address() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -388,7 +389,6 @@ fn test_remove_executed_hash_no_esdt_address_registered() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -414,7 +414,6 @@ fn test_remove_one_executed_hash() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -460,7 +459,6 @@ fn test_remove_all_executed_hashes() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -511,7 +509,6 @@ fn test_lock_operation_not_registered() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
@@ -536,7 +533,6 @@ fn test_lock_operation() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.change_validator_set(vec![ManagedBuffer::from("bls_1")], None);
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 

--- a/header-verifier/tests/header_verifier_blackbox_test.rs
+++ b/header-verifier/tests/header_verifier_blackbox_test.rs
@@ -100,7 +100,7 @@ impl HeaderVerifierTestState {
         self
     }
 
-    fn propose_register_esdt_address(&mut self, esdt_address: TestAddress) {
+    fn register_esdt_address(&mut self, esdt_address: TestAddress) {
         self.world
             .tx()
             .from(OWNER)
@@ -110,7 +110,7 @@ impl HeaderVerifierTestState {
             .run();
     }
 
-    fn propose_register_operations(
+    fn register_operations(
         &mut self,
         operation: BridgeOperation<StaticApi>,
         error_message: Option<&str>,
@@ -134,7 +134,7 @@ impl HeaderVerifierTestState {
         }
     }
 
-    fn propose_remove_executed_hash(
+    fn remove_executed_hash(
         &mut self,
         caller: TestAddress,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
@@ -156,7 +156,7 @@ impl HeaderVerifierTestState {
         }
     }
 
-    fn propose_lock_operation_hash(
+    fn lock_operation_hash(
         &mut self,
         caller: TestAddress,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
@@ -306,7 +306,7 @@ fn test_register_esdt_address() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     state
@@ -329,13 +329,13 @@ fn register_bridge_operation_setup_not_completed() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), Some("The setup phase must be completed"));
+    state.register_operations(operation.clone(), Some("The setup phase must be completed"));
 }
 
 #[test]
@@ -347,14 +347,14 @@ fn test_register_bridge_operation() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), None);
+    state.register_operations(operation.clone(), None);
 
     state
         .world
@@ -392,15 +392,15 @@ fn test_remove_executed_hash_caller_not_esdt_address() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), None);
-    state.propose_remove_executed_hash(
+    state.register_operations(operation.clone(), None);
+    state.remove_executed_hash(
         OWNER,
         &operation.bridge_operation_hash,
         &operation_1,
@@ -417,15 +417,15 @@ fn test_remove_executed_hash_no_esdt_address_registered() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), None);
-    state.propose_remove_executed_hash(
+    state.register_operations(operation.clone(), None);
+    state.remove_executed_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_1,
@@ -442,7 +442,7 @@ fn test_remove_one_executed_hash() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_hash_1 = ManagedBuffer::from("operation_1");
@@ -450,8 +450,8 @@ fn test_remove_one_executed_hash() {
     let operation =
         state.generate_bridge_operation_struct(vec![&operation_hash_1, &operation_hash_2]);
 
-    state.propose_register_operations(operation.clone(), None);
-    state.propose_remove_executed_hash(
+    state.register_operations(operation.clone(), None);
+    state.remove_executed_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_hash_1,
@@ -487,23 +487,23 @@ fn test_remove_all_executed_hashes() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), None);
+    state.register_operations(operation.clone(), None);
 
-    state.propose_remove_executed_hash(
+    state.remove_executed_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_1,
         None,
     );
 
-    state.propose_remove_executed_hash(
+    state.remove_executed_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_2,
@@ -537,14 +537,14 @@ fn test_lock_operation_not_registered() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_lock_operation_hash(
+    state.lock_operation_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_1,
@@ -561,16 +561,16 @@ fn test_lock_operation() {
         &SovereignConfig::new(0, 2, BigUint::default(), None),
         HEADER_VERIFIER_ADDRESS,
     );
-    state.propose_register_esdt_address(ENSHRINE_ADDRESS);
+    state.register_esdt_address(ENSHRINE_ADDRESS);
     state.complete_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
 
-    state.propose_register_operations(operation.clone(), None);
+    state.register_operations(operation.clone(), None);
 
-    state.propose_lock_operation_hash(
+    state.lock_operation_hash(
         ENSHRINE_ADDRESS,
         &operation.bridge_operation_hash,
         &operation_1,

--- a/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
+++ b/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",

--- a/sovereign-forge/wasm/Cargo.lock
+++ b/sovereign-forge/wasm/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "esdt-safe"
 version = "0.0.0"
 dependencies = [
+ "chain-config",
  "fee-market",
  "header-verifier",
  "max-bridged-amount-module",


### PR DESCRIPTION
Modified the operation registration logic in Header-Verifier to firstly check if the setup phase is completed. Also added test coverage and some cleanup.