### PR TITLE
ESDT-Safe optional config

### DIFF
--- a/common/proxies/src/mvx_esdt_safe_proxy.rs
+++ b/common/proxies/src/mvx_esdt_safe_proxy.rs
@@ -45,17 +45,17 @@ where
 {
     pub fn init<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-        Arg1: ProxyArg<operation::EsdtSafeConfig<Env::Api>>,
+        Arg1: ProxyArg<OptionalValue<operation::EsdtSafeConfig<Env::Api>>>,
     >(
         self,
         header_verifier_address: Arg0,
-        esdt_safe_config: Arg1,
+        opt_config: Arg1,
     ) -> TxTypedDeploy<Env, From, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_deploy()
             .argument(&header_verifier_address)
-            .argument(&esdt_safe_config)
+            .argument(&opt_config)
             .original_result()
     }
 }
@@ -88,6 +88,19 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn update_configuration<
+        Arg0: ProxyArg<operation::EsdtSafeConfig<Env::Api>>,
+    >(
+        self,
+        new_config: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("updateConfiguration")
+            .argument(&new_config)
+            .original_result()
+    }
+
     pub fn set_fee_market_address<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(

--- a/common/proxies/src/sov_esdt_safe_proxy.rs
+++ b/common/proxies/src/sov_esdt_safe_proxy.rs
@@ -44,15 +44,18 @@ where
     Gas: TxGas<Env>,
 {
     pub fn init<
-        Arg0: ProxyArg<operation::EsdtSafeConfig<Env::Api>>,
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+        Arg1: ProxyArg<OptionalValue<operation::EsdtSafeConfig<Env::Api>>>,
     >(
         self,
-        config: Arg0,
+        fee_market_address: Arg0,
+        opt_config: Arg1,
     ) -> TxTypedDeploy<Env, From, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_deploy()
-            .argument(&config)
+            .argument(&fee_market_address)
+            .argument(&opt_config)
             .original_result()
     }
 }
@@ -85,6 +88,19 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn update_configuration<
+        Arg0: ProxyArg<operation::EsdtSafeConfig<Env::Api>>,
+    >(
+        self,
+        new_config: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("updateConfiguration")
+            .argument(&new_config)
+            .original_result()
+    }
+
     pub fn set_fee_market_address<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
     >(

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -24,11 +24,22 @@ pub trait MvxEsdtSafe:
     fn init(
         &self,
         header_verifier_address: ManagedAddress,
-        esdt_safe_config: EsdtSafeConfig<Self::Api>,
+        opt_config: OptionalValue<EsdtSafeConfig<Self::Api>>,
     ) {
         self.require_sc_address(&header_verifier_address);
         self.header_verifier_address().set(&header_verifier_address);
-        self.esdt_safe_config().set(esdt_safe_config);
+
+        self.esdt_safe_config().set(
+            opt_config
+                .into_option()
+                .unwrap_or_else(EsdtSafeConfig::default_config),
+        );
+    }
+
+    #[only_owner]
+    #[endpoint(updateConfiguration)]
+    fn update_configuration(&self, new_config: EsdtSafeConfig<Self::Api>) {
+        self.esdt_safe_config().set(new_config);
     }
 
     #[only_owner]

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_setup.rs
@@ -1,5 +1,6 @@
 use multiversx_sc::{
     codec::TopEncode,
+    imports::OptionalValue,
     types::{
         BigUint, EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedVec, MultiValueEncoded,
         TestAddress, TestSCAddress, TestTokenIdentifier, TokenIdentifier,
@@ -110,13 +111,13 @@ impl MvxEsdtSafeTestState {
     pub fn deploy_contract(
         &mut self,
         header_verifier_address: TestSCAddress,
-        config: EsdtSafeConfig<StaticApi>,
+        opt_config: OptionalValue<EsdtSafeConfig<StaticApi>>,
     ) -> &mut Self {
         self.world
             .tx()
             .from(OWNER_ADDRESS)
             .typed(MvxEsdtSafeProxy)
-            .init(header_verifier_address, config)
+            .init(header_verifier_address, opt_config)
             .code(CONTRACT_CODE_PATH)
             .new_address(ESDT_SAFE_ADDRESS)
             .run();

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_unit_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_unit_tests.rs
@@ -27,14 +27,20 @@ mod mvx_esdt_safe_setup;
 fn deploy() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, EsdtSafeConfig::default_config());
+    state.deploy_contract(
+        HEADER_VERIFIER_ADDRESS,
+        OptionalValue::Some(EsdtSafeConfig::default_config()),
+    );
 }
 
 #[test]
 fn deposit_nothing_to_transfer() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, EsdtSafeConfig::default_config());
+    state.deploy_contract(
+        HEADER_VERIFIER_ADDRESS,
+        OptionalValue::Some(EsdtSafeConfig::default_config()),
+    );
     state.deposit(
         USER.to_managed_address(),
         OptionalValue::None,
@@ -47,7 +53,10 @@ fn deposit_nothing_to_transfer() {
 fn deposit_too_many_tokens() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, EsdtSafeConfig::default_config());
+    state.deploy_contract(
+        HEADER_VERIFIER_ADDRESS,
+        OptionalValue::Some(EsdtSafeConfig::default_config()),
+    );
 
     let esdt_token_payment = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(TEST_TOKEN_ONE),
@@ -69,7 +78,10 @@ fn deposit_too_many_tokens() {
 fn deposit_no_transfer_data() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, EsdtSafeConfig::default_config());
+    state.deploy_contract(
+        HEADER_VERIFIER_ADDRESS,
+        OptionalValue::Some(EsdtSafeConfig::default_config()),
+    );
     state.deploy_fee_market(None);
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
 
@@ -110,7 +122,7 @@ fn deposit_gas_limit_too_high() {
     let mut state = MvxEsdtSafeTestState::new();
 
     let config = EsdtSafeConfig::new(ManagedVec::new(), ManagedVec::new(), 1, ManagedVec::new());
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
+    state.deploy_contract(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
     state.deploy_fee_market(None);
     state.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
@@ -155,7 +167,7 @@ fn deposit_endpoint_banned() {
         ManagedVec::from(vec![ManagedBuffer::from("hello")]),
     );
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
+    state.deploy_contract(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
     state.deploy_fee_market(None);
     state.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
@@ -200,7 +212,7 @@ fn deposit_fee_enabled() {
         ManagedVec::new(),
     );
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
+    state.deploy_contract(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -292,7 +304,7 @@ fn deposit_payment_doesnt_cover_fee() {
         ManagedVec::new(),
     );
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
+    state.deploy_contract(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
 
     let fee = FeeStruct {
         base_token: TokenIdentifier::from(TEST_TOKEN_ONE),
@@ -347,7 +359,7 @@ fn deposit_refund() {
         ManagedVec::new(),
     );
 
-    state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
+    state.deploy_contract(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -434,7 +446,7 @@ fn deposit_refund() {
 #[test]
 fn register_token_not_enough_egld() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let sov_token_id = TestTokenIdentifier::new(TEST_TOKEN_ONE);
@@ -462,7 +474,7 @@ fn register_token_not_enough_egld() {
 #[test]
 fn register_token_invalid_type() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let sov_token_id = TestTokenIdentifier::new(TEST_TOKEN_ONE);
@@ -486,7 +498,7 @@ fn register_token_invalid_type() {
 #[test]
 fn register_token_fungible_token() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let sov_token_id = TestTokenIdentifier::new(TEST_TOKEN_ONE);
@@ -523,7 +535,7 @@ fn register_token_fungible_token() {
 #[test]
 fn register_token_nonfungible_token() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let sov_token_id = TestTokenIdentifier::new(TEST_TOKEN_ONE);
@@ -560,7 +572,7 @@ fn register_token_nonfungible_token() {
 #[test]
 fn execute_operation_no_esdt_safe_registered() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let payment = OperationEsdtPayment::new(
@@ -591,7 +603,7 @@ fn execute_operation_no_esdt_safe_registered() {
 #[test]
 fn execute_operation_success() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
+    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
     state.deploy_contract(HEADER_VERIFIER_ADDRESS, config);
 
     let token_data = EsdtTokenData {

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            9
+// Endpoints:                           10
 // Async Callback (empty):               1
 // Promise callbacks:                    2
-// Total number of exported functions:  14
+// Total number of exported functions:  15
 
 #![no_std]
 
@@ -21,6 +21,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
         deposit => deposit
         executeBridgeOps => execute_operations

--- a/mvx-esdt-safe/wasm/src/lib.rs
+++ b/mvx-esdt-safe/wasm/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            9
+// Endpoints:                           10
 // Async Callback (empty):               1
 // Promise callbacks:                    2
-// Total number of exported functions:  14
+// Total number of exported functions:  15
 
 #![no_std]
 
@@ -21,6 +21,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
         deposit => deposit
         executeBridgeOps => execute_operations

--- a/sov-esdt-safe/src/lib.rs
+++ b/sov-esdt-safe/src/lib.rs
@@ -18,8 +18,25 @@ pub trait SovEsdtSafe:
     + multiversx_sc_modules::pause::PauseModule
 {
     #[init]
-    fn init(&self, config: EsdtSafeConfig<Self::Api>) {
-        self.esdt_safe_config().set(config);
+    fn init(
+        &self,
+        fee_market_address: ManagedAddress,
+        opt_config: OptionalValue<EsdtSafeConfig<Self::Api>>,
+    ) {
+        self.require_sc_address(&fee_market_address);
+        self.fee_market_address().set(fee_market_address);
+
+        self.esdt_safe_config().set(
+            opt_config
+                .into_option()
+                .unwrap_or_else(EsdtSafeConfig::default_config),
+        );
+    }
+
+    #[only_owner]
+    #[endpoint(updateConfiguration)]
+    fn update_configuration(&self, new_config: EsdtSafeConfig<Self::Api>) {
+        self.esdt_safe_config().set(new_config);
     }
 
     #[only_owner]

--- a/sov-esdt-safe/tests/sov_esdt_safe_setup.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_setup.rs
@@ -1,5 +1,9 @@
-use multiversx_sc::types::{
-    BigUint, EsdtLocalRole, ManagedAddress, ManagedVec, TestAddress, TestSCAddress, TokenIdentifier,
+use multiversx_sc::{
+    imports::OptionalValue,
+    types::{
+        BigUint, EsdtLocalRole, ManagedAddress, ManagedVec, TestAddress, TestSCAddress,
+        TokenIdentifier,
+    },
 };
 use multiversx_sc_scenario::{
     api::StaticApi, imports::MxscPath, scenario_model::Log, ReturnsHandledOrError, ReturnsLogs,
@@ -84,12 +88,16 @@ impl SovEsdtSafeTestState {
         Self { world }
     }
 
-    pub fn deploy_contract(&mut self, config: EsdtSafeConfig<StaticApi>) -> &mut Self {
+    pub fn deploy_contract(
+        &mut self,
+        fee_market_address: TestSCAddress,
+        opt_config: OptionalValue<EsdtSafeConfig<StaticApi>>,
+    ) -> &mut Self {
         self.world
             .tx()
             .from(OWNER_ADDRESS)
             .typed(SovEsdtSafeProxy)
-            .init(config)
+            .init(fee_market_address, opt_config)
             .code(SOV_ESDT_SAFE_CODE_PATH)
             .new_address(ESDT_SAFE_ADDRESS)
             .run();
@@ -141,7 +149,10 @@ impl SovEsdtSafeTestState {
                     ManagedVec::new(),
                 );
 
-                sc.init(config);
+                sc.init(
+                    FEE_MARKET_ADDRESS.to_managed_address(),
+                    OptionalValue::Some(config),
+                );
             });
 
         self

--- a/sov-esdt-safe/tests/sov_esdt_safe_unit_tests.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_unit_tests.rs
@@ -18,7 +18,10 @@ mod sov_esdt_safe_setup;
 fn deploy() {
     let mut state = SovEsdtSafeTestState::new();
 
-    state.deploy_contract(EsdtSafeConfig::default_config());
+    state.deploy_contract(
+        FEE_MARKET_ADDRESS,
+        OptionalValue::Some(EsdtSafeConfig::default_config()),
+    );
 }
 
 #[test]

--- a/sov-esdt-safe/wasm-sov-esdt-safe-full/src/lib.rs
+++ b/sov-esdt-safe/wasm-sov-esdt-safe-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            7
+// Endpoints:                            8
 // Async Callback (empty):               1
-// Total number of exported functions:  10
+// Total number of exported functions:  11
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
         deposit => deposit
         setMaxBridgedAmount => set_max_bridged_amount

--- a/sov-esdt-safe/wasm/src/lib.rs
+++ b/sov-esdt-safe/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            7
+// Endpoints:                            8
 // Async Callback (empty):               1
-// Total number of exported functions:  10
+// Total number of exported functions:  11
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
         deposit => deposit
         setMaxBridgedAmount => set_max_bridged_amount


### PR DESCRIPTION
Modified in both the Sov-ESDT-Safe and Mvx-ESDT-Safe SC so that the `EsdtSafeConfig` parameter in `init` is now an `OptionalValue`. There is also a new endpoint in each SC so the config can be updated after deployment.

Also added the fee-market address inside the Sov-ESDT-Safe SC. 