### PR TITLE
Small SC changes

### DIFF
--- a/common/proxies/src/header_verifier_proxy.rs
+++ b/common/proxies/src/header_verifier_proxy.rs
@@ -43,16 +43,12 @@ where
     From: TxFrom<Env>,
     Gas: TxGas<Env>,
 {
-    pub fn init<
-        Arg0: ProxyArg<MultiValueEncoded<Env::Api, ManagedBuffer<Env::Api>>>,
-    >(
+    pub fn init(
         self,
-        bls_pub_keys: Arg0,
     ) -> TxTypedDeploy<Env, From, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_deploy()
-            .argument(&bls_pub_keys)
             .original_result()
     }
 }
@@ -85,6 +81,19 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn register_bls_pub_keys<
+        Arg0: ProxyArg<MultiValueEncoded<Env::Api, ManagedBuffer<Env::Api>>>,
+    >(
+        self,
+        bls_pub_keys: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("registerBlsPubKeys")
+            .argument(&bls_pub_keys)
+            .original_result()
+    }
+
     pub fn register_bridge_operations<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<ManagedBuffer<Env::Api>>,

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -14,10 +14,13 @@ pub enum OperationHashStatus {
 #[multiversx_sc::contract]
 pub trait Headerverifier {
     #[init]
-    fn init(&self, bls_pub_keys: MultiValueEncoded<ManagedBuffer>) {
-        for pub_key in bls_pub_keys {
-            self.bls_pub_keys().insert(pub_key);
-        }
+    fn init(&self) {}
+
+    #[only_owner]
+    #[endpoint(registerBlsPubKeys)]
+    fn register_bls_pub_keys(&self, bls_pub_keys: MultiValueEncoded<ManagedBuffer>) {
+        self.bls_pub_keys().clear();
+        self.bls_pub_keys().extend(bls_pub_keys);
     }
 
     #[upgrade]

--- a/header-verifier/tests/header_verifier_blackbox_setup.rs
+++ b/header-verifier/tests/header_verifier_blackbox_setup.rs
@@ -19,8 +19,6 @@ pub const ENSHRINE_ADDRESS: TestAddress = TestAddress::new("enshrine");
 pub const OWNER_ADDRESS: TestAddress = TestAddress::new("owner");
 const WEGLD_BALANCE: u128 = 100_000_000_000_000_000; // 0.1 WEGLD
 
-type BlsKeys = MultiValueEncoded<StaticApi, ManagedBuffer<StaticApi>>;
-
 #[derive(Clone)]
 pub struct BridgeOperation<M: ManagedTypeApi> {
     pub signature: ManagedBuffer<M>,
@@ -57,12 +55,12 @@ impl HeaderVerifierTestState {
         Self { world }
     }
 
-    pub fn deploy_header_verifier_contract(&mut self, bls_keys: BlsKeys) -> &mut Self {
+    pub fn deploy(&mut self) -> &mut Self {
         self.world
             .tx()
             .from(OWNER_ADDRESS)
             .typed(HeaderverifierProxy)
-            .init(bls_keys)
+            .init()
             .code(HEADER_VERIFIER_CODE_PATH)
             .new_address(HEADER_VERIFIER_ADDRESS)
             .run();
@@ -144,12 +142,6 @@ impl HeaderVerifierTestState {
             ),
             Err(error) => assert_eq!(expected_result, Some(error.message.as_str())),
         };
-    }
-
-    pub fn get_bls_keys(&mut self, bls_keys_vec: Vec<ManagedBuffer<StaticApi>>) -> BlsKeys {
-        let bls_keys = bls_keys_vec.iter().cloned().collect();
-
-        bls_keys
     }
 
     pub fn generate_bridge_operation_struct(

--- a/header-verifier/tests/header_verifier_blackbox_test.rs
+++ b/header-verifier/tests/header_verifier_blackbox_test.rs
@@ -8,19 +8,15 @@ mod header_verifier_blackbox_setup;
 #[test]
 fn test_deploy() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 }
 
 #[test]
 fn test_register_esdt_address() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
 
     state
@@ -37,10 +33,8 @@ fn test_register_esdt_address() {
 #[test]
 fn test_register_bridge_operation() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
@@ -78,10 +72,8 @@ fn test_register_bridge_operation() {
 #[test]
 fn test_remove_executed_hash_caller_not_esdt_address() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
@@ -100,10 +92,8 @@ fn test_remove_executed_hash_caller_not_esdt_address() {
 #[test]
 fn test_remove_executed_hash_no_esdt_address_registered() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
@@ -121,10 +111,8 @@ fn test_remove_executed_hash_no_esdt_address_registered() {
 #[test]
 fn test_remove_one_executed_hash() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 
     let operation_hash_1 = ManagedBuffer::from("operation_1");
     let operation_hash_2 = ManagedBuffer::from("operation_2");
@@ -164,10 +152,8 @@ fn test_remove_one_executed_hash() {
 #[test]
 fn test_remove_all_executed_hashes() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
 
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
@@ -211,10 +197,8 @@ fn test_remove_all_executed_hashes() {
 #[test]
 fn test_lock_operation_not_registered() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
 
     let operation_1 = ManagedBuffer::from("operation_1");
@@ -232,10 +216,8 @@ fn test_lock_operation_not_registered() {
 #[test]
 fn test_lock_operation() {
     let mut state = HeaderVerifierTestState::new();
-    let bls_key_1 = ManagedBuffer::from("bls_key_1");
-    let managed_bls_keys = state.get_bls_keys(vec![bls_key_1]);
 
-    state.deploy_header_verifier_contract(managed_bls_keys);
+    state.deploy();
     state.propose_register_esdt_address(ENSHRINE_ADDRESS);
 
     let operation_1 = ManagedBuffer::from("operation_1");

--- a/header-verifier/wasm-header-verifier-full/src/lib.rs
+++ b/header-verifier/wasm-header-verifier-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            4
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   7
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        registerBlsPubKeys => register_bls_pub_keys
         registerBridgeOps => register_bridge_operations
         setEsdtSafeAddress => set_esdt_safe_address
         removeExecutedHash => remove_executed_hash

--- a/header-verifier/wasm/src/lib.rs
+++ b/header-verifier/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            4
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   7
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        registerBlsPubKeys => register_bls_pub_keys
         registerBridgeOps => register_bridge_operations
         setEsdtSafeAddress => set_esdt_safe_address
         removeExecutedHash => remove_executed_hash

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -36,6 +36,8 @@ pub trait MvxEsdtSafe:
                 .inspect(|config| self.require_esdt_config_valid(config))
                 .unwrap_or_else(EsdtSafeConfig::default_config),
         );
+
+        self.set_paused(true);
     }
 
     #[only_owner]

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -2,8 +2,8 @@ use multiversx_sc::{
     codec::TopEncode,
     imports::{MultiValue2, OptionalValue},
     types::{
-        BigUint, EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedVec, MultiValueEncoded,
-        TestAddress, TestSCAddress, TestTokenIdentifier, TokenIdentifier,
+        BigUint, EsdtTokenType, ManagedAddress, ManagedBuffer, MultiValueEncoded, TestAddress,
+        TestSCAddress, TestTokenIdentifier, TokenIdentifier,
     },
 };
 use multiversx_sc_modules::transfer_role_proxy::PaymentsVec;
@@ -124,6 +124,14 @@ impl MvxEsdtSafeTestState {
             .new_address(ESDT_SAFE_ADDRESS)
             .run();
 
+        self.world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(ESDT_SAFE_ADDRESS)
+            .typed(MvxEsdtSafeProxy)
+            .unpause_endpoint()
+            .run();
+
         self
     }
 
@@ -177,15 +185,12 @@ impl MvxEsdtSafeTestState {
         self
     }
 
-    pub fn deploy_header_verifier(
-        &mut self,
-        bls_pub_keys: ManagedVec<StaticApi, ManagedBuffer<StaticApi>>,
-    ) -> &mut Self {
+    pub fn deploy_header_verifier(&mut self) -> &mut Self {
         self.world
             .tx()
             .from(OWNER_ADDRESS)
             .typed(HeaderverifierProxy)
-            .init(MultiValueEncoded::from(bls_pub_keys))
+            .init()
             .code(HEADER_VERIFIER_CODE_PATH)
             .new_address(HEADER_VERIFIER_ADDRESS)
             .run();

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_unit_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_unit_tests.rs
@@ -644,7 +644,7 @@ fn execute_operation_no_esdt_safe_registered() {
 
     let hash_of_hashes = state.get_operation_hash(&operation);
 
-    state.deploy_header_verifier(ManagedVec::new());
+    state.deploy_header_verifier();
 
     state.execute_operation(
         hash_of_hashes,
@@ -685,7 +685,7 @@ fn execute_operation_success() {
     let operation_hash = state.get_operation_hash(&operation);
     let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&operation_hash.to_vec()));
 
-    state.deploy_header_verifier(ManagedVec::new());
+    state.deploy_header_verifier();
     state.deploy_testing_sc();
     state.set_esdt_safe_address_in_header_verifier(ESDT_SAFE_ADDRESS);
 

--- a/sov-esdt-safe/src/lib.rs
+++ b/sov-esdt-safe/src/lib.rs
@@ -33,6 +33,8 @@ pub trait SovEsdtSafe:
                 .inspect(|config| self.require_esdt_config_valid(config))
                 .unwrap_or_else(EsdtSafeConfig::default_config),
         );
+
+        self.set_paused(true);
     }
 
     #[only_owner]

--- a/sov-esdt-safe/tests/sov_esdt_safe_setup.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_setup.rs
@@ -104,6 +104,14 @@ impl SovEsdtSafeTestState {
             .new_address(ESDT_SAFE_ADDRESS)
             .run();
 
+        self.world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(ESDT_SAFE_ADDRESS)
+            .typed(SovEsdtSafeProxy)
+            .unpause_endpoint()
+            .run();
+
         self
     }
 
@@ -176,6 +184,14 @@ impl SovEsdtSafeTestState {
                     OptionalValue::Some(config),
                 );
             });
+
+        self.world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(ESDT_SAFE_ADDRESS)
+            .typed(SovEsdtSafeProxy)
+            .unpause_endpoint()
+            .run();
 
         self
     }


### PR DESCRIPTION
Removed the `bls-keys` from the Header-Verifier `init` and also added the `set_paused` to `true` inside both ESDT-Safe scs.