### PR TITLE
Sovereign forge fixes after merge

### DIFF
--- a/common/proxies/src/sovereign_forge_proxy.rs
+++ b/common/proxies/src/sovereign_forge_proxy.rs
@@ -151,15 +151,15 @@ where
     }
 
     pub fn deploy_phase_three<
-        Arg0: ProxyArg<bool>,
+        Arg0: ProxyArg<OptionalValue<structs::configs::EsdtSafeConfig<Env::Api>>>,
     >(
         self,
-        is_sovereign_chain: Arg0,
+        opt_config: Arg0,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("deployPhaseThree")
-            .argument(&is_sovereign_chain)
+            .argument(&opt_config)
             .original_result()
     }
 

--- a/sovereign-forge/interactor/tests/interact_cs_tests.rs
+++ b/sovereign-forge/interactor/tests/interact_cs_tests.rs
@@ -1,26 +1,29 @@
-// #[tokio::test]
-// #[cfg_attr(not(feature = "chain-simulator-tests"), ignore)]
-// async fn deploy_test_sovereign_forge_cs() {
-//     let mut interactor = ContractInteract::new().await;
-//     interactor.deploy().await;
-//
-//     interactor.deploy_chain_config_template().await;
-//     interactor.deploy_header_verifier_template().await;
-//     interactor.deploy_esdt_safe_template().await;
-//     interactor.deploy_fee_market_template().await;
-//     interactor.deploy_chain_factory().await;
-//
-//     interactor.register_token_handler(1).await;
-//     interactor.register_token_handler(2).await;
-//     interactor.register_token_handler(3).await;
-//     interactor.register_chain_factory(1).await;
-//     interactor.register_chain_factory(2).await;
-//     interactor.register_chain_factory(3).await;
-//
-//     interactor.complete_setup_phase().await;
-//
-//     interactor.deploy_phase_one().await;
-//     interactor.deploy_phase_two().await;
-//     interactor.deploy_phase_three().await;
-//     interactor.deploy_phase_four().await;
-// }
+use forge_rust_interact::ContractInteract;
+use multiversx_sc_snippets::imports::tokio;
+
+#[tokio::test]
+#[cfg_attr(not(feature = "chain-simulator-tests"), ignore)]
+async fn deploy_test_sovereign_forge_cs() {
+    let mut interactor = ContractInteract::new().await;
+    interactor.deploy().await;
+
+    interactor.deploy_chain_config_template().await;
+    interactor.deploy_header_verifier_template().await;
+    interactor.deploy_mvx_esdt_safe_template().await;
+    interactor.deploy_fee_market_template().await;
+    interactor.deploy_chain_factory().await;
+
+    interactor.register_token_handler(1).await;
+    interactor.register_token_handler(2).await;
+    interactor.register_token_handler(3).await;
+    interactor.register_chain_factory(1).await;
+    interactor.register_chain_factory(2).await;
+    interactor.register_chain_factory(3).await;
+
+    interactor.complete_setup_phase().await;
+
+    interactor.deploy_phase_one().await;
+    interactor.deploy_phase_two().await;
+    interactor.deploy_phase_three().await;
+    interactor.deploy_phase_four().await;
+}

--- a/sovereign-forge/src/common/sc_deploy.rs
+++ b/sovereign-forge/src/common/sc_deploy.rs
@@ -1,7 +1,7 @@
 use crate::err_msg;
-use multiversx_sc::types::ReturnsResult;
+use multiversx_sc::{imports::OptionalValue, types::ReturnsResult};
 use proxies::{chain_factory_proxy::ChainFactoryContractProxy, fee_market_proxy::FeeStruct};
-use structs::configs::SovereignConfig;
+use structs::configs::{EsdtSafeConfig, SovereignConfig};
 
 #[multiversx_sc::module]
 pub trait ScDeployModule: super::utils::UtilsModule + super::storage::StorageModule {
@@ -25,20 +25,19 @@ pub trait ScDeployModule: super::utils::UtilsModule + super::storage::StorageMod
             .sync_call()
     }
 
+    // TODO: MVX & Sov
     #[inline]
-    fn deploy_esdt_safe(
+    fn deploy_mvx_esdt_safe(
         &self,
-        _is_sovereign_chain: bool,
-        _header_verifier_address: &ManagedAddress,
+        header_verifier_address: &ManagedAddress,
+        opt_config: OptionalValue<EsdtSafeConfig<Self::Api>>,
     ) -> ManagedAddress {
-        // self.tx()
-        //     .to(self.get_chain_factory_address())
-        //     .typed(ChainFactoryContractProxy)
-        //     .deploy_esdt_safe(is_sovereign_chain, header_verifier_address)
-        //     .returns(ReturnsResult)
-        //     .sync_call()
-
-        ManagedAddress::default()
+        self.tx()
+            .to(self.get_chain_factory_address())
+            .typed(ChainFactoryContractProxy)
+            .deploy_mvx_esdt_safe(header_verifier_address, opt_config)
+            .returns(ReturnsResult)
+            .sync_call()
     }
 
     #[inline]

--- a/sovereign-forge/src/phases.rs
+++ b/sovereign-forge/src/phases.rs
@@ -2,8 +2,8 @@ use crate::err_msg;
 use core::ops::Deref;
 use proxies::{chain_factory_proxy::ChainFactoryContractProxy, fee_market_proxy::FeeStruct};
 
-use multiversx_sc::require;
-use structs::configs::SovereignConfig;
+use multiversx_sc::{imports::OptionalValue, require};
+use structs::configs::{EsdtSafeConfig, SovereignConfig};
 
 use crate::common::{
     self,
@@ -110,7 +110,7 @@ pub trait PhasesModule:
     }
 
     #[endpoint(deployPhaseThree)]
-    fn deploy_phase_three(&self, is_sovereign_chain: bool) {
+    fn deploy_phase_three(&self, opt_config: OptionalValue<EsdtSafeConfig<Self::Api>>) {
         let caller = self.blockchain().get_caller();
 
         self.require_phase_two_completed(&caller);
@@ -121,7 +121,7 @@ pub trait PhasesModule:
 
         let header_verifier_address = self.get_contract_address(&caller, ScArray::HeaderVerifier);
 
-        let esdt_safe_address = self.deploy_esdt_safe(is_sovereign_chain, &header_verifier_address);
+        let esdt_safe_address = self.deploy_mvx_esdt_safe(&header_verifier_address, opt_config);
 
         let esdt_safe_contract_info =
             ContractInfo::new(ScArray::ESDTSafe, esdt_safe_address.clone());


### PR DESCRIPTION
For the sake of fixing and uncommenting code, the prior used contract of `ESDT-Safe` was replaced with `Mvx-ESDT-Safe`. In the future both the Mvx and Sov ESDT-Safe contracts will be used.