### PR TITLE
Fee-Market structs in common structs module

### DIFF
--- a/chain-factory/src/factory.rs
+++ b/chain-factory/src/factory.rs
@@ -1,13 +1,14 @@
 use multiversx_sc::imports::*;
 use multiversx_sc_modules::only_admin;
 use proxies::{
-    chain_config_proxy::ChainConfigContractProxy,
-    enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy,
-    fee_market_proxy::{FeeMarketProxy, FeeStruct},
-    header_verifier_proxy::HeaderverifierProxy,
+    chain_config_proxy::ChainConfigContractProxy, enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy,
+    fee_market_proxy::FeeMarketProxy, header_verifier_proxy::HeaderverifierProxy,
     mvx_esdt_safe_proxy::MvxEsdtSafeProxy,
 };
-use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use structs::{
+    configs::{EsdtSafeConfig, SovereignConfig},
+    fee::FeeStruct,
+};
 multiversx_sc::derive_imports!();
 
 #[multiversx_sc::module]

--- a/common/common-interactor/src/common_sovereign_interactor.rs
+++ b/common/common-interactor/src/common_sovereign_interactor.rs
@@ -24,18 +24,15 @@ use multiversx_sc_snippets::{
     Interactor, InteractorRunAsync,
 };
 use proxies::{
-    chain_config_proxy::ChainConfigContractProxy,
-    chain_factory_proxy::ChainFactoryContractProxy,
-    enshrine_esdt_safe_proxy,
-    fee_market_proxy::{FeeMarketProxy, FeeStruct},
-    header_verifier_proxy::HeaderverifierProxy,
-    mvx_esdt_safe_proxy::MvxEsdtSafeProxy,
-    sovereign_forge_proxy::SovereignForgeProxy,
-    testing_sc_proxy::TestingScProxy,
+    chain_config_proxy::ChainConfigContractProxy, chain_factory_proxy::ChainFactoryContractProxy,
+    enshrine_esdt_safe_proxy, fee_market_proxy::FeeMarketProxy,
+    header_verifier_proxy::HeaderverifierProxy, mvx_esdt_safe_proxy::MvxEsdtSafeProxy,
+    sovereign_forge_proxy::SovereignForgeProxy, testing_sc_proxy::TestingScProxy,
     token_handler_proxy,
 };
 use structs::{
     configs::{EsdtSafeConfig, SovereignConfig},
+    fee::FeeStruct,
     operation::Operation,
 };
 

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -22,18 +22,16 @@ use multiversx_sc_scenario::{
 };
 use mvx_esdt_safe::bridging_mechanism::BridgingMechanism;
 use proxies::{
-    chain_config_proxy::ChainConfigContractProxy,
-    chain_factory_proxy::ChainFactoryContractProxy,
-    enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy,
-    fee_market_proxy::{FeeMarketProxy, FeeStruct},
-    header_verifier_proxy::HeaderverifierProxy,
-    mvx_esdt_safe_proxy::MvxEsdtSafeProxy,
-    sov_esdt_safe_proxy::SovEsdtSafeProxy,
-    sovereign_forge_proxy::SovereignForgeProxy,
-    testing_sc_proxy::TestingScProxy,
-    token_handler_proxy::TokenHandlerProxy,
+    chain_config_proxy::ChainConfigContractProxy, chain_factory_proxy::ChainFactoryContractProxy,
+    enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy, fee_market_proxy::FeeMarketProxy,
+    header_verifier_proxy::HeaderverifierProxy, mvx_esdt_safe_proxy::MvxEsdtSafeProxy,
+    sov_esdt_safe_proxy::SovEsdtSafeProxy, sovereign_forge_proxy::SovereignForgeProxy,
+    testing_sc_proxy::TestingScProxy, token_handler_proxy::TokenHandlerProxy,
 };
-use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use structs::{
+    configs::{EsdtSafeConfig, SovereignConfig},
+    fee::FeeStruct,
+};
 
 pub struct RegisterTokenArgs<'a> {
     pub sov_token_id: TokenIdentifier<StaticApi>,

--- a/common/cross-chain/src/storage.rs
+++ b/common/cross-chain/src/storage.rs
@@ -1,5 +1,4 @@
-use proxies::fee_market_proxy::FeeType;
-use structs::{aliases::TxNonce, configs::EsdtSafeConfig, EsdtInfo};
+use structs::{aliases::TxNonce, configs::EsdtSafeConfig, fee::FeeType, EsdtInfo};
 
 multiversx_sc::imports!();
 

--- a/common/proxies/src/chain_factory_proxy.rs
+++ b/common/proxies/src/chain_factory_proxy.rs
@@ -182,7 +182,7 @@ where
 
     pub fn deploy_fee_market<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-        Arg1: ProxyArg<Option<super::fee_market_proxy::FeeStruct<Env::Api>>>,
+        Arg1: ProxyArg<Option<structs::fee::FeeStruct<Env::Api>>>,
     >(
         self,
         esdt_safe_address: Arg0,

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -45,7 +45,7 @@ where
 {
     pub fn init<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-        Arg1: ProxyArg<Option<FeeStruct<Env::Api>>>,
+        Arg1: ProxyArg<Option<structs::fee::FeeStruct<Env::Api>>>,
     >(
         self,
         esdt_safe_address: Arg0,
@@ -111,7 +111,7 @@ where
     }
 
     pub fn set_fee<
-        Arg0: ProxyArg<FeeStruct<Env::Api>>,
+        Arg0: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
     >(
         self,
         fee_struct: Arg0,
@@ -141,7 +141,7 @@ where
     >(
         self,
         token_id: Arg0,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, FeeType<Env::Api>> {
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, structs::fee::FeeType<Env::Api>> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("getTokenFee")
@@ -198,7 +198,7 @@ where
         original_caller: Arg0,
         total_transfers: Arg1,
         opt_gas_limit: Arg2,
-    ) -> TxTypedCall<Env, From, To, (), Gas, FinalPayment<Env::Api>> {
+    ) -> TxTypedCall<Env, From, To, (), Gas, structs::fee::FinalPayment<Env::Api>> {
         self.wrapped_tx
             .raw_call("subtractFee")
             .argument(&original_caller)
@@ -215,44 +215,4 @@ where
             .raw_call("getUsersWhitelist")
             .original_result()
     }
-}
-
-#[type_abi]
-#[derive(TopDecode, TopEncode, NestedEncode, NestedDecode, Clone)]
-pub struct FeeStruct<Api>
-where
-    Api: ManagedTypeApi,
-{
-    pub base_token: TokenIdentifier<Api>,
-    pub fee_type: FeeType<Api>,
-}
-
-#[rustfmt::skip]
-#[type_abi]
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, Clone)]
-pub enum FeeType<Api>
-where
-    Api: ManagedTypeApi,
-{
-    None,
-    Fixed {
-        token: TokenIdentifier<Api>,
-        per_transfer: BigUint<Api>,
-        per_gas: BigUint<Api>,
-    },
-    AnyToken {
-        base_fee_token: TokenIdentifier<Api>,
-        per_transfer: BigUint<Api>,
-        per_gas: BigUint<Api>,
-    },
-}
-
-#[type_abi]
-#[derive(TopEncode, TopDecode)]
-pub struct FinalPayment<Api>
-where
-    Api: ManagedTypeApi,
-{
-    pub fee: EsdtTokenPayment<Api>,
-    pub remaining_tokens: EsdtTokenPayment<Api>,
 }

--- a/common/proxies/src/sovereign_forge_proxy.rs
+++ b/common/proxies/src/sovereign_forge_proxy.rs
@@ -164,7 +164,7 @@ where
     }
 
     pub fn deploy_phase_four<
-        Arg0: ProxyArg<Option<super::fee_market_proxy::FeeStruct<Env::Api>>>,
+        Arg0: ProxyArg<Option<structs::fee::FeeStruct<Env::Api>>>,
     >(
         self,
         fee: Arg0,

--- a/common/structs/src/fee.rs
+++ b/common/structs/src/fee.rs
@@ -1,0 +1,49 @@
+use crate::aliases::GasLimit;
+
+multiversx_sc::imports!();
+multiversx_sc::derive_imports!();
+
+#[type_abi]
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, Clone)]
+pub enum FeeType<M: ManagedTypeApi> {
+    None,
+    Fixed {
+        token: TokenIdentifier<M>,
+        per_transfer: BigUint<M>,
+        per_gas: BigUint<M>,
+    },
+    AnyToken {
+        base_fee_token: TokenIdentifier<M>,
+        per_transfer: BigUint<M>,
+        per_gas: BigUint<M>,
+    },
+}
+
+#[type_abi]
+#[derive(TopDecode, TopEncode, NestedEncode, NestedDecode, Clone)]
+pub struct FeeStruct<M: ManagedTypeApi> {
+    pub base_token: TokenIdentifier<M>,
+    pub fee_type: FeeType<M>,
+}
+
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub struct FinalPayment<M: ManagedTypeApi> {
+    pub fee: EsdtTokenPayment<M>,
+    pub remaining_tokens: EsdtTokenPayment<M>,
+}
+
+#[derive(TopEncode, TopDecode, ManagedVecItem)]
+pub struct AddressPercentagePair<M: ManagedTypeApi> {
+    pub address: ManagedAddress<M>,
+    pub percentage: usize,
+}
+
+pub struct SubtractPaymentArguments<M: ManagedTypeApi> {
+    pub fee_token: TokenIdentifier<M>,
+    pub per_transfer: BigUint<M>,
+    pub per_gas: BigUint<M>,
+    pub payment: EsdtTokenPayment<M>,
+    pub total_transfers: usize,
+    pub opt_gas_limit: OptionalValue<GasLimit>,
+}

--- a/common/structs/src/lib.rs
+++ b/common/structs/src/lib.rs
@@ -6,6 +6,7 @@ multiversx_sc::derive_imports!();
 pub mod aliases;
 pub mod configs;
 pub mod events;
+pub mod fee;
 pub mod operation;
 
 pub const MIN_BLOCKS_FOR_FINALITY: u64 = 10;

--- a/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_setup.rs
+++ b/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_setup.rs
@@ -21,14 +21,13 @@ use multiversx_sc_scenario::{
     ScenarioTxRun,
 };
 use proxies::{
-    enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy,
-    fee_market_proxy::{FeeMarketProxy, FeeStruct, FeeType},
-    header_verifier_proxy::HeaderverifierProxy,
-    token_handler_proxy::TokenHandlerProxy,
+    enshrine_esdt_safe_proxy::EnshrineEsdtSafeProxy, fee_market_proxy::FeeMarketProxy,
+    header_verifier_proxy::HeaderverifierProxy, token_handler_proxy::TokenHandlerProxy,
 };
 use structs::{
     aliases::{GasLimit, OptionalValueTransferDataTuple, PaymentsVec},
     configs::{EsdtSafeConfig, SovereignConfig},
+    fee::{FeeStruct, FeeType},
     operation::{Operation, OperationData, OperationEsdtPayment},
 };
 

--- a/fee-market/src/fee_type.rs
+++ b/fee-market/src/fee_type.rs
@@ -1,30 +1,8 @@
 use error_messages::{INVALID_FEE, INVALID_FEE_TYPE};
+use structs::fee::{FeeStruct, FeeType};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
-
-#[type_abi]
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, Clone)]
-pub enum FeeType<M: ManagedTypeApi> {
-    None,
-    Fixed {
-        token: TokenIdentifier<M>,
-        per_transfer: BigUint<M>,
-        per_gas: BigUint<M>,
-    },
-    AnyToken {
-        base_fee_token: TokenIdentifier<M>,
-        per_transfer: BigUint<M>,
-        per_gas: BigUint<M>,
-    },
-}
-
-#[type_abi]
-#[derive(TopDecode, TopEncode, NestedEncode, NestedDecode, Clone)]
-pub struct FeeStruct<M: ManagedTypeApi> {
-    pub base_token: TokenIdentifier<M>,
-    pub fee_type: FeeType<M>,
-}
 
 #[multiversx_sc::module]
 pub trait FeeTypeModule: utils::UtilsModule {

--- a/fee-market/src/lib.rs
+++ b/fee-market/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use error_messages::ESDT_SAFE_ADDRESS_NOT_SET;
-use fee_type::FeeStruct;
+use structs::fee::FeeStruct;
 
 multiversx_sc::imports!();
 

--- a/fee-market/src/subtract_fee.rs
+++ b/fee-market/src/subtract_fee.rs
@@ -2,36 +2,15 @@ use error_messages::{
     INVALID_PERCENTAGE_SUM, INVALID_TOKEN_PROVIDED_FOR_FEE, PAYMENT_DOES_NOT_COVER_FEE,
     TOKEN_NOT_ACCEPTED_AS_FEE,
 };
-use structs::aliases::GasLimit;
-
-use crate::fee_type::FeeType;
+use structs::{
+    aliases::GasLimit,
+    fee::{AddressPercentagePair, FeeType, FinalPayment, SubtractPaymentArguments},
+};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
 const TOTAL_PERCENTAGE: usize = 10_000;
-
-#[type_abi]
-#[derive(TopEncode, TopDecode)]
-pub struct FinalPayment<M: ManagedTypeApi> {
-    pub fee: EsdtTokenPayment<M>,
-    pub remaining_tokens: EsdtTokenPayment<M>,
-}
-
-#[derive(TopEncode, TopDecode, ManagedVecItem)]
-pub struct AddressPercentagePair<M: ManagedTypeApi> {
-    pub address: ManagedAddress<M>,
-    pub percentage: usize,
-}
-
-pub struct SubtractPaymentArguments<M: ManagedTypeApi> {
-    pub fee_token: TokenIdentifier<M>,
-    pub per_transfer: BigUint<M>,
-    pub per_gas: BigUint<M>,
-    pub payment: EsdtTokenPayment<M>,
-    pub total_transfers: usize,
-    pub opt_gas_limit: OptionalValue<GasLimit>,
-}
 
 #[multiversx_sc::module]
 pub trait SubtractFeeModule:

--- a/fee-market/tests/fee_market_blackbox_setup.rs
+++ b/fee-market/tests/fee_market_blackbox_setup.rs
@@ -5,7 +5,6 @@ use multiversx_sc::{
     },
 };
 use multiversx_sc_scenario::{api::StaticApi, ReturnsHandledOrError, ScenarioTxRun};
-use proxies::fee_market_proxy::{FeeMarketProxy, FeeStruct, FeeType};
 
 use common_test_setup::{
     constants::{
@@ -15,6 +14,8 @@ use common_test_setup::{
     },
     AccountSetup, BaseSetup,
 };
+use proxies::fee_market_proxy::FeeMarketProxy;
+use structs::fee::{FeeStruct, FeeType};
 
 pub struct FeeMarketTestState {
     pub common_setup: BaseSetup,

--- a/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
+++ b/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
@@ -1,12 +1,12 @@
 use common_interactor::common_sovereign_interactor::CommonInteractorTrait;
 use multiversx_sc_snippets::imports::*;
 use multiversx_sc_snippets::sdk::gateway::SetStateAccount;
-use proxies::fee_market_proxy::FeeStruct;
 use proxies::header_verifier_proxy::HeaderverifierProxy;
 use proxies::mvx_esdt_safe_proxy::MvxEsdtSafeProxy;
 use structs::aliases::{OptionalValueTransferDataTuple, PaymentsVec};
 
 use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use structs::fee::FeeStruct;
 use structs::operation::Operation;
 
 use common_interactor::interactor_config::Config;

--- a/interactor/tests/mvx_esdt_safe_tests.rs
+++ b/interactor/tests/mvx_esdt_safe_tests.rs
@@ -12,11 +12,11 @@ use error_messages::{
 use header_verifier::OperationHashStatus;
 use multiversx_sc_snippets::multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_snippets::{hex, imports::*};
-use proxies::fee_market_proxy::{FeeStruct, FeeType};
 use rust_interact::mvx_esdt_safe::mvx_esdt_safe_interactor_main::MvxEsdtSafeInteract;
 use serial_test::serial;
 use structs::aliases::PaymentsVec;
 use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use structs::fee::{FeeStruct, FeeType};
 use structs::operation::{Operation, OperationData, OperationEsdtPayment, TransferData};
 
 // Test that deposit fails when there is nothing to transfer and fee is disabled

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -26,9 +26,9 @@ use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{api::StaticApi, ScenarioTxWhitebox};
 use mvx_esdt_safe::bridging_mechanism::{BridgingMechanism, TRUSTED_TOKEN_IDS};
 use mvx_esdt_safe_blackbox_setup::MvxEsdtSafeTestState;
-use proxies::fee_market_proxy::{FeeStruct, FeeType};
 use setup_phase::SetupPhaseModule;
 use structs::configs::{MaxBridgedAmount, SovereignConfig};
+use structs::fee::{FeeStruct, FeeType};
 use structs::operation::TransferData;
 use structs::{
     aliases::PaymentsVec,

--- a/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
@@ -8,9 +8,12 @@ use multiversx_sc::{
     types::{BigUint, EsdtTokenPayment, ManagedBuffer, ManagedVec, MultiValueEncoded},
 };
 use multiversx_sc_scenario::api::StaticApi;
-use proxies::fee_market_proxy::{FeeStruct, FeeType};
 use sov_esdt_safe_blackbox_setup::SovEsdtSafeTestState;
-use structs::{aliases::PaymentsVec, configs::EsdtSafeConfig};
+use structs::{
+    aliases::PaymentsVec,
+    configs::EsdtSafeConfig,
+    fee::{FeeStruct, FeeType},
+};
 
 mod sov_esdt_safe_blackbox_setup;
 

--- a/sovereign-forge/src/common/sc_deploy.rs
+++ b/sovereign-forge/src/common/sc_deploy.rs
@@ -1,7 +1,10 @@
 use crate::err_msg;
 use multiversx_sc::{imports::OptionalValue, types::ReturnsResult};
-use proxies::{chain_factory_proxy::ChainFactoryContractProxy, fee_market_proxy::FeeStruct};
-use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use proxies::chain_factory_proxy::ChainFactoryContractProxy;
+use structs::{
+    configs::{EsdtSafeConfig, SovereignConfig},
+    fee::FeeStruct,
+};
 
 #[multiversx_sc::module]
 pub trait ScDeployModule: super::utils::UtilsModule + super::storage::StorageModule {

--- a/sovereign-forge/src/phases.rs
+++ b/sovereign-forge/src/phases.rs
@@ -4,10 +4,13 @@ use error_messages::{
     CHAIN_CONFIG_ALREADY_DEPLOYED, ESDT_SAFE_ALREADY_DEPLOYED, FEE_MARKET_ALREADY_DEPLOYED,
     HEADER_VERIFIER_ALREADY_DEPLOYED, SOVEREIGN_SETUP_PHASE_ALREADY_COMPLETED,
 };
-use proxies::{chain_factory_proxy::ChainFactoryContractProxy, fee_market_proxy::FeeStruct};
+use proxies::chain_factory_proxy::ChainFactoryContractProxy;
 
 use multiversx_sc::{imports::OptionalValue, require};
-use structs::configs::{EsdtSafeConfig, SovereignConfig};
+use structs::{
+    configs::{EsdtSafeConfig, SovereignConfig},
+    fee::FeeStruct,
+};
 
 use crate::common::{
     self,


### PR DESCRIPTION
Since the fee-market structs are used in most other contracts, importing them through the proxy would be error proned especially for blackbox testing. 

With this PR those structs are moved to the common structs module.