### PR TITLE
Hash locking for config update endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ name = "chain-config"
 version = "0.1.0"
 dependencies = [
  "common-test-setup",
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/chain-config/Cargo.toml
+++ b/chain-config/Cargo.toml
@@ -32,5 +32,8 @@ path = "../common/setup-phase"
 [dependencies.error-messages]
 path = "../common/error-messages"
 
+[dependencies.cross-chain]
+path = "../common/cross-chain"
+
 [dev-dependencies.common-test-setup]
 path = "../common/common-test-setup"

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -36,7 +36,7 @@ pub trait ChainConfigContract:
         self.lock_operation_hash(&config_hash, &hash_of_hashes);
 
         if let Some(error_message) = self.is_new_config_valid(&new_config) {
-            self.update_sovereign_config_fail_event(
+            self.failed_bridge_operation_event(
                 &hash_of_hashes,
                 &config_hash,
                 &ManagedBuffer::from(error_message),

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use cross_chain::{execute_common, storage};
+use cross_chain::events;
 use structs::{configs::SovereignConfig, generate_hash::GenerateHash};
 
 multiversx_sc::imports!();
@@ -9,10 +9,7 @@ pub mod validator_rules;
 
 #[multiversx_sc::contract]
 pub trait ChainConfigContract:
-    validator_rules::ValidatorRulesModule
-    + setup_phase::SetupPhaseModule
-    + execute_common::ExecuteCommonModule
-    + storage::CrossChainStorage
+    validator_rules::ValidatorRulesModule + setup_phase::SetupPhaseModule + events::EventsModule
 {
     #[init]
     fn init(&self, config: SovereignConfig<Self::Api>) {
@@ -33,22 +30,24 @@ pub trait ChainConfigContract:
         hash_of_hashes: ManagedBuffer,
         new_config: SovereignConfig<Self::Api>,
     ) {
-        let opt_hash = if self.is_setup_phase_complete() {
-            Some(new_config.generate_hash())
-        } else {
-            None
-        };
+        self.require_setup_complete();
 
-        if let Some(ref config_hash) = opt_hash {
-            self.lock_operation_hash(config_hash, &hash_of_hashes);
+        let config_hash = new_config.generate_hash();
+        self.lock_operation_hash(&config_hash, &hash_of_hashes);
+
+        if let Some(error_message) = self.is_new_config_valid(&new_config) {
+            self.update_sovereign_config_fail_event(
+                &hash_of_hashes,
+                &config_hash,
+                &ManagedBuffer::from(error_message),
+            );
+
+            return;
         }
 
-        self.require_valid_config(&new_config);
         self.sovereign_config().set(new_config);
-
-        if let Some(config_hash) = opt_hash {
-            self.remove_executed_hash(&hash_of_hashes, &config_hash);
-        }
+        self.remove_executed_hash(&hash_of_hashes, &config_hash);
+        self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }
 
     #[only_owner]

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -21,6 +21,12 @@ pub trait ChainConfigContract:
     }
 
     #[only_owner]
+    #[endpoint(updateSovereignConfigSetupPhase)]
+    fn update_sovereign_config_during_setup_phase(&self, new_config: SovereignConfig<Self::Api>) {
+        self.require_valid_config(&new_config);
+        self.sovereign_config().set(new_config);
+    }
+
     #[endpoint(updateSovereignConfig)]
     fn update_sovereign_config(
         &self,

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -21,8 +21,12 @@ pub trait ChainConfigContract:
     }
 
     #[only_owner]
-    #[endpoint(updateConfig)]
-    fn update_config(&self, hash_of_hashes: ManagedBuffer, new_config: SovereignConfig<Self::Api>) {
+    #[endpoint(updateSovereignConfig)]
+    fn update_sovereign_config(
+        &self,
+        hash_of_hashes: ManagedBuffer,
+        new_config: SovereignConfig<Self::Api>,
+    ) {
         let opt_hash = if self.is_setup_phase_complete() {
             Some(new_config.generate_hash())
         } else {

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -41,11 +41,10 @@ pub trait ChainConfigContract:
                 &config_hash,
                 &ManagedBuffer::from(error_message),
             );
-
-            return;
+        } else {
+            self.sovereign_config().set(new_config);
         }
 
-        self.sovereign_config().set(new_config);
         self.remove_executed_hash(&hash_of_hashes, &config_hash);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -20,7 +20,9 @@ pub trait ChainConfigContract:
     #[only_owner]
     #[endpoint(updateSovereignConfigSetupPhase)]
     fn update_sovereign_config_during_setup_phase(&self, new_config: SovereignConfig<Self::Api>) {
-        self.require_valid_config(&new_config);
+        if let Some(error_message) = self.is_new_config_valid(&new_config) {
+            sc_panic!(error_message);
+        }
         self.sovereign_config().set(new_config);
     }
 

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -1,4 +1,5 @@
 use error_messages::INVALID_MIN_MAX_VALIDATOR_NUMBERS;
+use proxies::header_verifier_proxy::HeaderverifierProxy;
 use structs::configs::SovereignConfig;
 
 multiversx_sc::imports!();
@@ -23,6 +24,30 @@ pub trait ValidatorRulesModule {
             min_validators <= max_validators,
             INVALID_MIN_MAX_VALIDATOR_NUMBERS
         );
+    }
+
+    fn is_new_config_valid(&self, config: &SovereignConfig<Self::Api>) -> Option<&str> {
+        if config.min_validators <= config.max_validators {
+            None
+        } else {
+            Some(INVALID_MIN_MAX_VALIDATOR_NUMBERS)
+        }
+    }
+
+    fn lock_operation_hash(&self, hash_of_hashes: &ManagedBuffer, hash: &ManagedBuffer) {
+        self.tx()
+            .to(self.blockchain().get_owner_address())
+            .typed(HeaderverifierProxy)
+            .lock_operation_hash(hash_of_hashes, hash)
+            .sync_call();
+    }
+
+    fn remove_executed_hash(&self, hash_of_hashes: &ManagedBuffer, op_hash: &ManagedBuffer) {
+        self.tx()
+            .to(self.blockchain().get_owner_address())
+            .typed(HeaderverifierProxy)
+            .remove_executed_hash(hash_of_hashes, op_hash)
+            .sync_call();
     }
 
     #[view(sovereignConfig)]

--- a/chain-config/tests/chain_config_blackbox_setup.rs
+++ b/chain-config/tests/chain_config_blackbox_setup.rs
@@ -2,6 +2,7 @@ use common_test_setup::{
     constants::{CHAIN_CONFIG_ADDRESS, OWNER_ADDRESS, OWNER_BALANCE},
     AccountSetup, BaseSetup,
 };
+use multiversx_sc::types::ManagedBuffer;
 use multiversx_sc_scenario::{api::StaticApi, ReturnsHandledOrError, ScenarioTxRun};
 use proxies::chain_config_proxy::ChainConfigContractProxy;
 use structs::configs::SovereignConfig;
@@ -29,6 +30,7 @@ impl ChainConfigTestState {
 
     pub fn update_chain_config(
         &mut self,
+        hash_of_hashes: ManagedBuffer<StaticApi>,
         config: SovereignConfig<StaticApi>,
         expect_error: Option<&str>,
     ) {
@@ -39,7 +41,7 @@ impl ChainConfigTestState {
             .from(OWNER_ADDRESS)
             .to(CHAIN_CONFIG_ADDRESS)
             .typed(ChainConfigContractProxy)
-            .update_config(config)
+            .update_config(hash_of_hashes, config)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/chain-config/tests/chain_config_blackbox_setup.rs
+++ b/chain-config/tests/chain_config_blackbox_setup.rs
@@ -41,7 +41,7 @@ impl ChainConfigTestState {
             .from(OWNER_ADDRESS)
             .to(CHAIN_CONFIG_ADDRESS)
             .typed(ChainConfigContractProxy)
-            .update_config(hash_of_hashes, config)
+            .update_sovereign_config(hash_of_hashes, config)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/chain-config/tests/chain_config_blackbox_tests.rs
+++ b/chain-config/tests/chain_config_blackbox_tests.rs
@@ -116,7 +116,7 @@ fn test_update_config_setup_phase_not_completed() {
 /// Call 'update_chain_config()'  with an invalid config
 ///
 /// ### EXPECTED
-/// updateSovereignConfigFail event is emitted
+/// failedBridgeOp event is emitted
 #[test]
 fn test_update_config_invalid_config() {
     let mut state = ChainConfigTestState::new();
@@ -146,12 +146,7 @@ fn test_update_config_invalid_config() {
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
-    state.update_sovereign_config(
-        hash_of_hashes,
-        new_config,
-        None,
-        Some("updateSovereignConfigFail"),
-    );
+    state.update_sovereign_config(hash_of_hashes, new_config, None, Some("failedBridgeOp"));
 }
 
 /// ### TEST

--- a/chain-config/tests/chain_config_blackbox_tests.rs
+++ b/chain-config/tests/chain_config_blackbox_tests.rs
@@ -81,7 +81,7 @@ fn test_complete_setup_phase() {
 /// C-CONFIG_UPDATE_CONFIG_FAIL_004
 ///
 /// ### ACTION
-/// Call 'update_chain_config()' during the setup phase
+/// Call 'update_sovereign_config()' during the setup phase
 ///
 /// ### EXPECTED
 /// Error SETUP_PHASE_NOT_COMPLETED
@@ -110,10 +110,10 @@ fn test_update_config_setup_phase_not_completed() {
 }
 
 /// ### TEST
-/// C-CONFIG_UPDATE_CONFIG_FAIL_005
+/// C-CONFIG_UPDATE_CONFIG_OK_005
 ///
 /// ### ACTION
-/// Call 'update_chain_config()'  with an invalid config
+/// Call 'update_sovereign_config()'  with an invalid config
 ///
 /// ### EXPECTED
 /// failedBridgeOp event is emitted
@@ -150,10 +150,10 @@ fn test_update_config_invalid_config() {
 }
 
 /// ### TEST
-/// C-CONFIG_UPDATE_CONFIG_FAIL_005
+/// C-CONFIG_UPDATE_CONFIG_OK_006
 ///
 /// ### ACTION
-/// Call 'update_chain_config()'  
+/// Call 'update_sovereign_config()'  
 ///
 /// ### EXPECTED
 /// executedBridgeOp event is emitted

--- a/chain-config/tests/chain_config_blackbox_tests.rs
+++ b/chain-config/tests/chain_config_blackbox_tests.rs
@@ -1,6 +1,6 @@
 use chain_config_blackbox_setup::ChainConfigTestState;
 use error_messages::INVALID_MIN_MAX_VALIDATOR_NUMBERS;
-use multiversx_sc::types::BigUint;
+use multiversx_sc::types::{BigUint, ManagedBuffer};
 use structs::configs::SovereignConfig;
 
 mod chain_config_blackbox_setup;
@@ -30,7 +30,7 @@ fn test_update_config() {
 
     let new_config = SovereignConfig::new(2, 4, BigUint::default(), None);
 
-    state.update_chain_config(new_config, None);
+    state.update_chain_config(ManagedBuffer::new(), new_config, None);
 }
 
 /// ### TEST
@@ -50,7 +50,11 @@ fn test_update_config_wrong_validators_array() {
 
     let new_config = SovereignConfig::new(2, 1, BigUint::default(), None);
 
-    state.update_chain_config(new_config, Some(INVALID_MIN_MAX_VALIDATOR_NUMBERS));
+    state.update_chain_config(
+        ManagedBuffer::new(),
+        new_config,
+        Some(INVALID_MIN_MAX_VALIDATOR_NUMBERS),
+    );
 }
 
 /// ### TEST

--- a/chain-config/tests/chain_config_blackbox_tests.rs
+++ b/chain-config/tests/chain_config_blackbox_tests.rs
@@ -1,7 +1,10 @@
+use chain_config::validator_rules::ValidatorRulesModule;
 use chain_config_blackbox_setup::ChainConfigTestState;
-use error_messages::INVALID_MIN_MAX_VALIDATOR_NUMBERS;
-use multiversx_sc::types::{BigUint, ManagedBuffer};
-use structs::configs::SovereignConfig;
+use common_test_setup::{constants::CHAIN_CONFIG_ADDRESS, CallerAddress};
+use error_messages::{INVALID_MIN_MAX_VALIDATOR_NUMBERS, SETUP_PHASE_NOT_COMPLETED};
+use multiversx_sc::types::{BigUint, ManagedBuffer, MultiValueEncoded};
+use multiversx_sc_scenario::{multiversx_chain_vm::crypto_functions::sha256, ScenarioTxWhitebox};
+use structs::{configs::SovereignConfig, generate_hash::GenerateHash};
 
 mod chain_config_blackbox_setup;
 
@@ -14,15 +17,15 @@ fn test_deploy_chain_config() {
 }
 
 /// ### TEST
-/// C-CONFIG_UPDATE_CONFIG_OK_001
+/// C-CONFIG_UPDATE_CONFIG_DURING_SETUP_PHASE_OK_001
 ///
 /// ### ACTION
-/// Call 'update_chain_config()' with a new valid config
+/// Call 'update_chain_config_during_setup_phase()' with a new valid config
 ///
 /// ### EXPECTED
 /// Chain config is updated with the new config
 #[test]
-fn test_update_config() {
+fn test_update_config_during_setup_phase() {
     let mut state = ChainConfigTestState::new();
 
     let config = SovereignConfig::new(0, 1, BigUint::default(), None);
@@ -30,19 +33,19 @@ fn test_update_config() {
 
     let new_config = SovereignConfig::new(2, 4, BigUint::default(), None);
 
-    state.update_chain_config(ManagedBuffer::new(), new_config, None);
+    state.update_sovereign_config_during_setup_phase(new_config, None);
 }
 
 /// ### TEST
-/// C-CONFIG_UPDATE_CONFIG_FAIL_002
+/// C-CONFIG_UPDATE_CONFIG_DURING_SETUP_PHASE_FAIL_002
 ///
 /// ### ACTION
-/// Call 'update_chain_config()' with an new invalid config
+/// Call 'update_chain_config_during_setup_phase()' with an new invalid config
 ///
 /// ### EXPECTED
 /// Error INVALID_MIN_MAX_VALIDATOR_NUMBERS
 #[test]
-fn test_update_config_wrong_validators_array() {
+fn test_update_config_during_setup_phase_wrong_validators_array() {
     let mut state = ChainConfigTestState::new();
 
     let config = SovereignConfig::new(0, 1, BigUint::default(), None);
@@ -50,8 +53,7 @@ fn test_update_config_wrong_validators_array() {
 
     let new_config = SovereignConfig::new(2, 1, BigUint::default(), None);
 
-    state.update_chain_config(
-        ManagedBuffer::new(),
+    state.update_sovereign_config_during_setup_phase(
         new_config,
         Some(INVALID_MIN_MAX_VALIDATOR_NUMBERS),
     );
@@ -73,4 +75,131 @@ fn test_complete_setup_phase() {
     state.common_setup.deploy_chain_config(config);
 
     state.common_setup.complete_chain_config_setup_phase(None);
+}
+
+/// ### TEST
+/// C-CONFIG_UPDATE_CONFIG_FAIL_004
+///
+/// ### ACTION
+/// Call 'update_chain_config()' during the setup phase
+///
+/// ### EXPECTED
+/// Error SETUP_PHASE_NOT_COMPLETED
+#[test]
+fn test_update_config_setup_phase_not_completed() {
+    let mut state = ChainConfigTestState::new();
+
+    let config = SovereignConfig::new(0, 1, BigUint::default(), None);
+    state.common_setup.deploy_chain_config(config);
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    let new_config = SovereignConfig::new(2, 1, BigUint::default(), None);
+
+    state.update_sovereign_config(
+        ManagedBuffer::new(),
+        new_config,
+        Some(SETUP_PHASE_NOT_COMPLETED),
+        None,
+    );
+}
+
+/// ### TEST
+/// C-CONFIG_UPDATE_CONFIG_FAIL_005
+///
+/// ### ACTION
+/// Call 'update_chain_config()'  with an invalid config
+///
+/// ### EXPECTED
+/// updateSovereignConfigFail event is emitted
+#[test]
+fn test_update_config_invalid_config() {
+    let mut state = ChainConfigTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(SovereignConfig::default_config());
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    let new_config = SovereignConfig::new(2, 1, BigUint::default(), None);
+
+    let config_hash = new_config.generate_hash();
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&config_hash.to_vec()));
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![config_hash]),
+    );
+
+    state.common_setup.complete_chain_config_setup_phase(None);
+
+    state.update_sovereign_config(
+        hash_of_hashes,
+        new_config,
+        None,
+        Some("updateSovereignConfigFail"),
+    );
+}
+
+/// ### TEST
+/// C-CONFIG_UPDATE_CONFIG_FAIL_005
+///
+/// ### ACTION
+/// Call 'update_chain_config()'  
+///
+/// ### EXPECTED
+/// executedBridgeOp event is emitted
+#[test]
+fn test_update_config() {
+    let mut state = ChainConfigTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(SovereignConfig::default_config());
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    let new_config = SovereignConfig::new(1, 2, BigUint::default(), None);
+
+    let config_hash = new_config.generate_hash();
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&config_hash.to_vec()));
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![config_hash]),
+    );
+
+    state.common_setup.complete_chain_config_setup_phase(None);
+
+    state.update_sovereign_config(hash_of_hashes, new_config, None, Some("executedBridgeOp"));
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(CHAIN_CONFIG_ADDRESS)
+        .whitebox(chain_config::contract_obj, |sc| {
+            let config = sc.sovereign_config().get();
+            assert!(config.min_validators == 1 && config.max_validators == 2);
+        });
 }

--- a/chain-config/wasm-chain-config-full/Cargo.lock
+++ b/chain-config/wasm-chain-config-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -38,6 +39,18 @@ version = "0.0.0"
 dependencies = [
  "chain-config",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]
@@ -255,3 +268,12 @@ name = "unwrap-infallible"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "structs",
+]

--- a/chain-config/wasm-chain-config-full/src/lib.rs
+++ b/chain-config/wasm-chain-config-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            4
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   7
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -24,6 +24,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed
+        getNativeToken => native_token
     )
 }
 

--- a/chain-config/wasm-chain-config-full/src/lib.rs
+++ b/chain-config/wasm-chain-config-full/src/lib.rs
@@ -20,7 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
-        updateConfig => update_config
+        updateSovereignConfig => update_sovereign_config
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed

--- a/chain-config/wasm-chain-config-full/src/lib.rs
+++ b/chain-config/wasm-chain-config-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            5
+// Endpoints:                            6
 // Async Callback (empty):               1
-// Total number of exported functions:   8
+// Total number of exported functions:   9
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateSovereignConfigSetupPhase => update_sovereign_config_during_setup_phase
         updateSovereignConfig => update_sovereign_config
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config

--- a/chain-config/wasm-chain-config-full/src/lib.rs
+++ b/chain-config/wasm-chain-config-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            6
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   9
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -25,7 +25,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed
-        getNativeToken => native_token
     )
 }
 

--- a/chain-config/wasm-chain-config-view/Cargo.lock
+++ b/chain-config/wasm-chain-config-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -38,6 +39,18 @@ version = "0.0.0"
 dependencies = [
  "chain-config",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]
@@ -255,3 +268,12 @@ name = "unwrap-infallible"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "structs",
+]

--- a/chain-config/wasm-chain-config/Cargo.lock
+++ b/chain-config/wasm-chain-config/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -38,6 +39,18 @@ version = "0.0.0"
 dependencies = [
  "chain-config",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]
@@ -255,3 +268,12 @@ name = "unwrap-infallible"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "structs",
+]

--- a/chain-config/wasm-chain-config/src/lib.rs
+++ b/chain-config/wasm-chain-config/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            4
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   7
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -24,6 +24,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed
+        getNativeToken => native_token
     )
 }
 

--- a/chain-config/wasm-chain-config/src/lib.rs
+++ b/chain-config/wasm-chain-config/src/lib.rs
@@ -20,7 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
-        updateConfig => update_config
+        updateSovereignConfig => update_sovereign_config
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed

--- a/chain-config/wasm-chain-config/src/lib.rs
+++ b/chain-config/wasm-chain-config/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            5
+// Endpoints:                            6
 // Async Callback (empty):               1
-// Total number of exported functions:   8
+// Total number of exported functions:   9
 
 #![no_std]
 
@@ -20,6 +20,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateSovereignConfigSetupPhase => update_sovereign_config_during_setup_phase
         updateSovereignConfig => update_sovereign_config
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config

--- a/chain-config/wasm-chain-config/src/lib.rs
+++ b/chain-config/wasm-chain-config/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            6
+// Endpoints:                            5
 // Async Callback (empty):               1
-// Total number of exported functions:   9
+// Total number of exported functions:   8
 
 #![no_std]
 
@@ -25,7 +25,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         completeSetupPhase => complete_setup_phase
         sovereignConfig => sovereign_config
         wasPreviouslySlashed => was_previously_slashed
-        getNativeToken => native_token
     )
 }
 

--- a/chain-factory/src/update_configs.rs
+++ b/chain-factory/src/update_configs.rs
@@ -22,7 +22,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(esdt_safe_address)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(new_config)
+            .update_configuration(ManagedBuffer::new(), new_config)
             .sync_call();
     }
 

--- a/chain-factory/src/update_configs.rs
+++ b/chain-factory/src/update_configs.rs
@@ -36,7 +36,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(chain_config_address)
             .typed(ChainConfigContractProxy)
-            .update_config(new_config)
+            .update_config(ManagedBuffer::new(), new_config)
             .sync_call();
     }
 

--- a/chain-factory/src/update_configs.rs
+++ b/chain-factory/src/update_configs.rs
@@ -22,7 +22,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(esdt_safe_address)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(ManagedBuffer::new(), new_config)
+            .update_esdt_safe_config(ManagedBuffer::new(), new_config)
             .sync_call();
     }
 
@@ -36,7 +36,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(chain_config_address)
             .typed(ChainConfigContractProxy)
-            .update_config(ManagedBuffer::new(), new_config)
+            .update_sovereign_config(ManagedBuffer::new(), new_config)
             .sync_call();
     }
 

--- a/chain-factory/src/update_configs.rs
+++ b/chain-factory/src/update_configs.rs
@@ -22,7 +22,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(esdt_safe_address)
             .typed(MvxEsdtSafeProxy)
-            .update_esdt_safe_config(ManagedBuffer::new(), new_config)
+            .update_esdt_safe_config_during_setup_phase(new_config)
             .sync_call();
     }
 
@@ -36,7 +36,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(chain_config_address)
             .typed(ChainConfigContractProxy)
-            .update_sovereign_config(ManagedBuffer::new(), new_config)
+            .update_sovereign_config_during_setup_phase(new_config)
             .sync_call();
     }
 

--- a/chain-factory/wasm-chain-factory-full/Cargo.lock
+++ b/chain-factory/wasm-chain-factory-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -51,6 +52,18 @@ version = "0.0.0"
 dependencies = [
  "chain-factory",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]

--- a/chain-factory/wasm-chain-factory-view/Cargo.lock
+++ b/chain-factory/wasm-chain-factory-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -51,6 +52,18 @@ version = "0.0.0"
 dependencies = [
  "chain-factory",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]

--- a/chain-factory/wasm-chain-factory/Cargo.lock
+++ b/chain-factory/wasm-chain-factory/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -51,6 +52,18 @@ version = "0.0.0"
 dependencies = [
  "chain-factory",
  "multiversx-sc-wasm-adapter",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
 ]
 
 [[package]]

--- a/common/cross-chain/src/events.rs
+++ b/common/cross-chain/src/events.rs
@@ -26,4 +26,12 @@ pub trait EventsModule {
         #[indexed] hash_of_hashes: &ManagedBuffer,
         #[indexed] hash_of_bridge_op: &ManagedBuffer,
     );
+
+    #[event("updateSovereignConfigFail")]
+    fn update_sovereign_config_fail_event(
+        &self,
+        #[indexed] hash_of_hashes: &ManagedBuffer,
+        #[indexed] hash: &ManagedBuffer,
+        error_message: &ManagedBuffer,
+    );
 }

--- a/common/cross-chain/src/events.rs
+++ b/common/cross-chain/src/events.rs
@@ -27,8 +27,8 @@ pub trait EventsModule {
         #[indexed] hash_of_bridge_op: &ManagedBuffer,
     );
 
-    #[event("updateSovereignConfigFail")]
-    fn update_sovereign_config_fail_event(
+    #[event("failedBridgeOp")]
+    fn failed_bridge_operation_event(
         &self,
         #[indexed] hash_of_hashes: &ManagedBuffer,
         #[indexed] hash: &ManagedBuffer,

--- a/common/cross-chain/src/execute_common.rs
+++ b/common/cross-chain/src/execute_common.rs
@@ -1,6 +1,5 @@
 use error_messages::NO_HEADER_VERIFIER_ADDRESS;
 use proxies::header_verifier_proxy::HeaderverifierProxy;
-use structs::operation::Operation;
 
 multiversx_sc::imports!();
 

--- a/common/cross-chain/src/execute_common.rs
+++ b/common/cross-chain/src/execute_common.rs
@@ -6,24 +6,11 @@ multiversx_sc::imports!();
 
 #[multiversx_sc::module]
 pub trait ExecuteCommonModule: crate::storage::CrossChainStorage {
-    fn calculate_operation_hash(&self, operation: &Operation<Self::Api>) -> ManagedBuffer {
-        let mut serialized_data = ManagedBuffer::new();
-
-        if let core::result::Result::Err(err) = operation.top_encode(&mut serialized_data) {
-            sc_panic!("Transfer data encode error: {}", err.message_bytes());
-        }
-
-        let sha256 = self.crypto().sha256(&serialized_data);
-        let hash = sha256.as_managed_buffer().clone();
-
-        hash
-    }
-
-    fn lock_operation_hash(&self, operation_hash: &ManagedBuffer, hash_of_hashes: &ManagedBuffer) {
+    fn lock_operation_hash(&self, hash_of_hashes: &ManagedBuffer, hash: &ManagedBuffer) {
         self.tx()
             .to(self.get_header_verifier_address())
             .typed(HeaderverifierProxy)
-            .lock_operation_hash(hash_of_hashes, operation_hash)
+            .lock_operation_hash(hash_of_hashes, hash)
             .sync_call();
     }
 

--- a/common/cross-chain/src/lib.rs
+++ b/common/cross-chain/src/lib.rs
@@ -16,13 +16,6 @@ pub const MAX_GAS_PER_TRANSACTION: u64 = 600_000_000;
 
 #[multiversx_sc::module]
 pub trait LibCommon: crate::storage::CrossChainStorage {
-    fn require_esdt_config_valid(&self, config: &EsdtSafeConfig<Self::Api>) {
-        require!(
-            config.max_tx_gas_limit < MAX_GAS_PER_TRANSACTION,
-            MAX_GAS_LIMIT_PER_TX_EXCEEDED
-        );
-    }
-
     fn is_esdt_safe_config_valid(&self, config: &EsdtSafeConfig<Self::Api>) -> Option<&str> {
         if config.max_tx_gas_limit < MAX_GAS_PER_TRANSACTION {
             None

--- a/common/cross-chain/src/lib.rs
+++ b/common/cross-chain/src/lib.rs
@@ -22,4 +22,12 @@ pub trait LibCommon: crate::storage::CrossChainStorage {
             MAX_GAS_LIMIT_PER_TX_EXCEEDED
         );
     }
+
+    fn is_esdt_safe_config_valid(&self, config: &EsdtSafeConfig<Self::Api>) -> Option<&str> {
+        if config.max_tx_gas_limit < MAX_GAS_PER_TRANSACTION {
+            None
+        } else {
+            Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED)
+        }
+    }
 }

--- a/common/proxies/src/chain_config_proxy.rs
+++ b/common/proxies/src/chain_config_proxy.rs
@@ -144,13 +144,4 @@ where
             .argument(&validator)
             .original_result()
     }
-
-    pub fn native_token(
-        self,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, TokenIdentifier<Env::Api>> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("getNativeToken")
-            .original_result()
-    }
 }

--- a/common/proxies/src/chain_config_proxy.rs
+++ b/common/proxies/src/chain_config_proxy.rs
@@ -85,6 +85,19 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn update_sovereign_config_during_setup_phase<
+        Arg0: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,
+    >(
+        self,
+        new_config: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("updateSovereignConfigSetupPhase")
+            .argument(&new_config)
+            .original_result()
+    }
+
     pub fn update_sovereign_config<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,

--- a/common/proxies/src/chain_config_proxy.rs
+++ b/common/proxies/src/chain_config_proxy.rs
@@ -85,7 +85,7 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
-    pub fn update_config<
+    pub fn update_sovereign_config<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,
     >(
@@ -95,7 +95,7 @@ where
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
-            .raw_call("updateConfig")
+            .raw_call("updateSovereignConfig")
             .argument(&hash_of_hashes)
             .argument(&new_config)
             .original_result()

--- a/common/proxies/src/chain_config_proxy.rs
+++ b/common/proxies/src/chain_config_proxy.rs
@@ -128,4 +128,13 @@ where
             .argument(&validator)
             .original_result()
     }
+
+    pub fn native_token(
+        self,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, TokenIdentifier<Env::Api>> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("getNativeToken")
+            .original_result()
+    }
 }

--- a/common/proxies/src/chain_config_proxy.rs
+++ b/common/proxies/src/chain_config_proxy.rs
@@ -86,14 +86,17 @@ where
     Gas: TxGas<Env>,
 {
     pub fn update_config<
-        Arg0: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,
     >(
         self,
-        new_config: Arg0,
+        hash_of_hashes: Arg0,
+        new_config: Arg1,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("updateConfig")
+            .argument(&hash_of_hashes)
             .argument(&new_config)
             .original_result()
     }

--- a/common/proxies/src/header_verifier_proxy.rs
+++ b/common/proxies/src/header_verifier_proxy.rs
@@ -196,19 +196,6 @@ where
             .original_result()
     }
 
-    pub fn update_config<
-        Arg0: ProxyArg<structs::configs::SovereignConfig<Env::Api>>,
-    >(
-        self,
-        new_config: Arg0,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("updateConfig")
-            .argument(&new_config)
-            .original_result()
-    }
-
     pub fn complete_setup_phase(
         self,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {

--- a/common/proxies/src/mvx_esdt_safe_proxy.rs
+++ b/common/proxies/src/mvx_esdt_safe_proxy.rs
@@ -88,6 +88,19 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
+    pub fn update_esdt_safe_config_during_setup_phase<
+        Arg0: ProxyArg<structs::configs::EsdtSafeConfig<Env::Api>>,
+    >(
+        self,
+        new_config: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("updateEsdtSafeConfigSetupPhase")
+            .argument(&new_config)
+            .original_result()
+    }
+
     pub fn update_esdt_safe_config<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<structs::configs::EsdtSafeConfig<Env::Api>>,
@@ -122,7 +135,7 @@ where
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
-            .raw_call("completSetupPhase")
+            .raw_call("completeSetupPhase")
             .original_result()
     }
 

--- a/common/proxies/src/mvx_esdt_safe_proxy.rs
+++ b/common/proxies/src/mvx_esdt_safe_proxy.rs
@@ -89,14 +89,17 @@ where
     Gas: TxGas<Env>,
 {
     pub fn update_configuration<
-        Arg0: ProxyArg<structs::configs::EsdtSafeConfig<Env::Api>>,
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<structs::configs::EsdtSafeConfig<Env::Api>>,
     >(
         self,
-        new_config: Arg0,
+        hash_of_hashes: Arg0,
+        new_config: Arg1,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("updateConfiguration")
+            .argument(&hash_of_hashes)
             .argument(&new_config)
             .original_result()
     }

--- a/common/proxies/src/mvx_esdt_safe_proxy.rs
+++ b/common/proxies/src/mvx_esdt_safe_proxy.rs
@@ -88,7 +88,7 @@ where
     To: TxTo<Env>,
     Gas: TxGas<Env>,
 {
-    pub fn update_configuration<
+    pub fn update_esdt_safe_config<
         Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
         Arg1: ProxyArg<structs::configs::EsdtSafeConfig<Env::Api>>,
     >(
@@ -98,7 +98,7 @@ where
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
-            .raw_call("updateConfiguration")
+            .raw_call("updateEsdtSafeConfig")
             .argument(&hash_of_hashes)
             .argument(&new_config)
             .original_result()

--- a/common/structs/src/configs.rs
+++ b/common/structs/src/configs.rs
@@ -1,4 +1,6 @@
-use crate::{aliases::GasLimit, DEFAULT_MAX_TX_GAS_LIMIT};
+use multiversx_sc::api::CryptoApi;
+
+use crate::{aliases::GasLimit, generate_hash::GenerateHash, DEFAULT_MAX_TX_GAS_LIMIT};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
@@ -13,6 +15,8 @@ pub struct SovereignConfig<M: ManagedTypeApi> {
     pub min_stake: BigUint<M>,
     pub opt_additional_stake_required: Option<ManagedVec<M, StakeArgs<M>>>,
 }
+
+impl<A: CryptoApi> GenerateHash<A> for SovereignConfig<A> {}
 
 impl<M: ManagedTypeApi> SovereignConfig<M> {
     pub fn new(
@@ -96,3 +100,5 @@ impl<M: ManagedTypeApi> EsdtSafeConfig<M> {
         }
     }
 }
+
+impl<A: CryptoApi> GenerateHash<A> for EsdtSafeConfig<A> {}

--- a/common/structs/src/configs.rs
+++ b/common/structs/src/configs.rs
@@ -72,6 +72,8 @@ pub struct EsdtSafeConfig<M: ManagedTypeApi> {
     pub max_bridged_token_amounts: ManagedVec<M, MaxBridgedAmount<M>>,
 }
 
+impl<A: CryptoApi> GenerateHash<A> for EsdtSafeConfig<A> {}
+
 impl<M: ManagedTypeApi> EsdtSafeConfig<M> {
     #[inline]
     pub fn default_config() -> Self {
@@ -100,5 +102,3 @@ impl<M: ManagedTypeApi> EsdtSafeConfig<M> {
         }
     }
 }
-
-impl<A: CryptoApi> GenerateHash<A> for EsdtSafeConfig<A> {}

--- a/common/structs/src/generate_hash.rs
+++ b/common/structs/src/generate_hash.rs
@@ -1,0 +1,25 @@
+use multiversx_sc::{
+    api::{CryptoApi, CryptoApiImpl, SHA256_RESULT_LEN},
+    codec::TopEncode,
+    types::{ManagedBuffer, ManagedByteArray, ManagedType},
+};
+
+pub trait GenerateHash<A: CryptoApi>
+where
+    Self: TopEncode,
+{
+    fn generate_hash(&self) -> ManagedBuffer<A> {
+        let mut serialized_data = ManagedBuffer::<A>::new();
+
+        if self.top_encode(&mut serialized_data).is_err() {
+            return ManagedBuffer::new();
+        }
+
+        unsafe {
+            let result: ManagedByteArray<A, SHA256_RESULT_LEN> = ManagedByteArray::new_uninit();
+            A::crypto_api_impl().sha256_managed(result.get_handle(), serialized_data.get_handle());
+
+            result.as_managed_buffer().clone()
+        }
+    }
+}

--- a/common/structs/src/lib.rs
+++ b/common/structs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod aliases;
 pub mod configs;
 pub mod events;
 pub mod fee;
+pub mod generate_hash;
 pub mod operation;
 
 pub const MIN_BLOCKS_FOR_FINALITY: u64 = 10;

--- a/common/structs/src/operation.rs
+++ b/common/structs/src/operation.rs
@@ -1,6 +1,10 @@
 use aliases::{GasLimit, OptionalValueTransferDataTuple, TxId};
+use multiversx_sc::api::CryptoApi;
 
-use crate::aliases::{self, EventPaymentTuple, TransferDataTuple};
+use crate::{
+    aliases::{self, EventPaymentTuple, TransferDataTuple},
+    generate_hash::GenerateHash,
+};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
@@ -40,6 +44,8 @@ impl<M: ManagedTypeApi> Operation<M> {
         tuples
     }
 }
+
+impl<A: CryptoApi> GenerateHash<A> for Operation<A> {}
 
 #[type_abi]
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem, Clone)]

--- a/common/structs/src/operation.rs
+++ b/common/structs/src/operation.rs
@@ -17,6 +17,8 @@ pub struct Operation<M: ManagedTypeApi> {
     pub data: OperationData<M>,
 }
 
+impl<A: CryptoApi> GenerateHash<A> for Operation<A> {}
+
 impl<M: ManagedTypeApi> Operation<M> {
     #[inline]
     pub fn new(
@@ -44,8 +46,6 @@ impl<M: ManagedTypeApi> Operation<M> {
         tuples
     }
 }
-
-impl<A: CryptoApi> GenerateHash<A> for Operation<A> {}
 
 #[type_abi]
 #[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, ManagedVecItem, Clone)]

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -5,7 +5,10 @@ use error_messages::{
 };
 use multiversx_sc::imports::*;
 use proxies::token_handler_proxy::TokenHandlerProxy;
-use structs::operation::{Operation, OperationData, OperationEsdtPayment, OperationTuple};
+use structs::{
+    generate_hash::GenerateHash,
+    operation::{Operation, OperationData, OperationEsdtPayment, OperationTuple},
+};
 
 const DEFAULT_ISSUE_COST: u64 = 50_000_000_000_000_000; // 0.05 * 10^18
 
@@ -44,9 +47,9 @@ pub trait TransferTokensModule:
         require!(!is_sovereign_chain, INVALID_METHOD_TO_CALL_IN_CURRENT_CHAIN);
         require!(self.not_paused(), CANNOT_TRANSFER_WHILE_PAUSED);
 
-        let op_hash = self.calculate_operation_hash(&operation);
+        let op_hash = operation.generate_hash();
 
-        self.lock_operation_hash(&op_hash, &hash_of_hashes);
+        self.lock_operation_hash(&hash_of_hashes, &op_hash);
 
         let split_result = self.split_payments_for_prefix_and_fee(&operation.tokens);
         if !split_result.are_tokens_registered {

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -169,6 +169,8 @@ pub trait Headerverifier:
         );
     }
 
+    // TODO:
+    // This needs to check for all the Sovereign Contracts
     fn require_caller_esdt_safe(&self) {
         let esdt_safe_mapper = self.esdt_safe_address();
 

--- a/header-verifier/src/lib.rs
+++ b/header-verifier/src/lib.rs
@@ -7,7 +7,6 @@ use error_messages::{
 };
 use multiversx_sc::codec;
 use multiversx_sc::proxy_imports::{TopDecode, TopEncode};
-use proxies::chain_config_proxy::ChainConfigContractProxy;
 use structs::configs::SovereignConfig;
 
 multiversx_sc::imports!();
@@ -144,17 +143,6 @@ pub trait Headerverifier:
                 sc_panic!(CURRENT_OPERATION_ALREADY_IN_EXECUTION)
             }
         }
-    }
-
-    #[endpoint(updateConfig)]
-    fn update_config(&self, new_config: SovereignConfig<Self::Api>) {
-        // TODO: verify signature
-
-        self.tx()
-            .to(self.chain_config_address().get())
-            .typed(ChainConfigContractProxy)
-            .update_config(new_config)
-            .sync_call();
     }
 
     #[only_owner]

--- a/header-verifier/tests/header_verifier_blackbox_setup.rs
+++ b/header-verifier/tests/header_verifier_blackbox_setup.rs
@@ -194,6 +194,8 @@ impl HeaderVerifierTestState {
         }
     }
 
+    // TODO:
+    // Cleanup, use the example from chain-config tests
     pub fn get_operation_hash(
         &mut self,
         operation: &ManagedBuffer<StaticApi>,

--- a/header-verifier/wasm-header-verifier-full/src/lib.rs
+++ b/header-verifier/wasm-header-verifier-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            8
+// Endpoints:                            7
 // Async Callback (empty):               1
-// Total number of exported functions:  11
+// Total number of exported functions:  10
 
 #![no_std]
 
@@ -26,7 +26,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         setEsdtSafeAddress => set_esdt_safe_address
         removeExecutedHash => remove_executed_hash
         lockOperationHash => lock_operation_hash
-        updateConfig => update_config
         completeSetupPhase => complete_setup_phase
     )
 }

--- a/header-verifier/wasm-header-verifier/src/lib.rs
+++ b/header-verifier/wasm-header-verifier/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                            8
+// Endpoints:                            7
 // Async Callback (empty):               1
-// Total number of exported functions:  11
+// Total number of exported functions:  10
 
 #![no_std]
 
@@ -26,7 +26,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         setEsdtSafeAddress => set_esdt_safe_address
         removeExecutedHash => remove_executed_hash
         lockOperationHash => lock_operation_hash
-        updateConfig => update_config
         completeSetupPhase => complete_setup_phase
     )
 }

--- a/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
+++ b/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
@@ -142,7 +142,11 @@ impl MvxEsdtSafeInteract {
         println!("Result: {response:?}");
     }
 
-    pub async fn update_configuration(&mut self, new_config: EsdtSafeConfig<StaticApi>) {
+    pub async fn update_configuration(
+        &mut self,
+        hash_of_hashes: &ManagedBuffer<StaticApi>,
+        new_config: EsdtSafeConfig<StaticApi>,
+    ) {
         let response = self
             .interactor
             .tx()
@@ -150,7 +154,7 @@ impl MvxEsdtSafeInteract {
             .to(self.state.current_mvx_esdt_safe_contract_address())
             .gas(90_000_000u64)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(new_config)
+            .update_configuration(hash_of_hashes, new_config)
             .returns(ReturnsResultUnmanaged)
             .run()
             .await;

--- a/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
+++ b/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
@@ -142,11 +142,7 @@ impl MvxEsdtSafeInteract {
         println!("Result: {response:?}");
     }
 
-    pub async fn update_configuration(
-        &mut self,
-        hash_of_hashes: &ManagedBuffer<StaticApi>,
-        new_config: EsdtSafeConfig<StaticApi>,
-    ) {
+    pub async fn update_configuration(&mut self, new_config: EsdtSafeConfig<StaticApi>) {
         let response = self
             .interactor
             .tx()
@@ -154,7 +150,7 @@ impl MvxEsdtSafeInteract {
             .to(self.state.current_mvx_esdt_safe_contract_address())
             .gas(90_000_000u64)
             .typed(MvxEsdtSafeProxy)
-            .update_esdt_safe_config(hash_of_hashes, new_config)
+            .update_esdt_safe_config_during_setup_phase(new_config)
             .returns(ReturnsResultUnmanaged)
             .run()
             .await;

--- a/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
+++ b/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
@@ -154,7 +154,7 @@ impl MvxEsdtSafeInteract {
             .to(self.state.current_mvx_esdt_safe_contract_address())
             .gas(90_000_000u64)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(hash_of_hashes, new_config)
+            .update_esdt_safe_config(hash_of_hashes, new_config)
             .returns(ReturnsResultUnmanaged)
             .run()
             .await;

--- a/mvx-esdt-safe/src/execute.rs
+++ b/mvx-esdt-safe/src/execute.rs
@@ -1,6 +1,7 @@
 use error_messages::ESDT_SAFE_STILL_PAUSED;
 use structs::{
     aliases::GasLimit,
+    generate_hash::GenerateHash,
     operation::{Operation, OperationData, OperationEsdtPayment, OperationTuple},
 };
 
@@ -25,7 +26,7 @@ pub trait ExecuteModule:
         require!(self.not_paused(), ESDT_SAFE_STILL_PAUSED);
         self.require_setup_complete();
 
-        let operation_hash = self.calculate_operation_hash(&operation);
+        let operation_hash = operation.generate_hash();
 
         self.lock_operation_hash(&operation_hash, &hash_of_hashes);
 

--- a/mvx-esdt-safe/src/execute.rs
+++ b/mvx-esdt-safe/src/execute.rs
@@ -28,7 +28,7 @@ pub trait ExecuteModule:
 
         let operation_hash = operation.generate_hash();
 
-        self.lock_operation_hash(&operation_hash, &hash_of_hashes);
+        self.lock_operation_hash(&hash_of_hashes, &operation_hash);
 
         let operation_tuple = OperationTuple {
             op_hash: operation_hash,

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -48,6 +48,12 @@ pub trait MvxEsdtSafe:
     fn upgrade(&self) {}
 
     #[only_owner]
+    #[endpoint(updateEsdtSafeConfigSetupPhase)]
+    fn update_esdt_safe_config_during_setup_phase(&self, new_config: EsdtSafeConfig<Self::Api>) {
+        self.require_esdt_config_valid(&new_config);
+        self.esdt_safe_config().set(new_config);
+    }
+
     #[endpoint(updateEsdtSafeConfig)]
     fn update_esdt_safe_config(
         &self,
@@ -80,7 +86,7 @@ pub trait MvxEsdtSafe:
     }
 
     #[only_owner]
-    #[endpoint(completSetupPhase)]
+    #[endpoint(completeSetupPhase)]
     fn complete_setup_phase(&self) {
         require!(
             !self.is_setup_phase_complete(),

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -48,8 +48,8 @@ pub trait MvxEsdtSafe:
     fn upgrade(&self) {}
 
     #[only_owner]
-    #[endpoint(updateConfiguration)]
-    fn update_configuration(
+    #[endpoint(updateEsdtSafeConfig)]
+    fn update_esdt_safe_config(
         &self,
         hash_of_hashes: ManagedBuffer,
         new_config: EsdtSafeConfig<Self::Api>,

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -73,9 +73,10 @@ pub trait MvxEsdtSafe:
             );
 
             return;
+        } else {
+            self.esdt_safe_config().set(new_config);
         }
 
-        self.esdt_safe_config().set(new_config);
         self.remove_executed_hash(&hash_of_hashes, &config_hash);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -79,8 +79,6 @@ pub trait MvxEsdtSafe:
                 &config_hash,
                 &ManagedBuffer::from(error_message),
             );
-
-            return;
         } else {
             self.esdt_safe_config().set(new_config);
         }

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -12,7 +12,6 @@ use multiversx_sc::{
     },
 };
 use multiversx_sc_modules::transfer_role_proxy::PaymentsVec;
-use multiversx_sc_scenario::ReturnsTxHash;
 use multiversx_sc_scenario::{
     api::StaticApi, ReturnsHandledOrError, ReturnsLogs, ScenarioTxRun, ScenarioTxWhitebox,
 };

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -128,12 +128,12 @@ impl MvxEsdtSafeTestState {
         self
     }
 
-    pub fn update_configuration(
+    pub fn update_esdt_safe_config_during_setup_phase(
         &mut self,
         new_config: EsdtSafeConfig<StaticApi>,
         err_message: Option<&str>,
     ) {
-        let response = self
+        let result = self
             .common_setup
             .world
             .tx()
@@ -145,7 +145,34 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, err_message);
+            .assert_expected_error_message(result, err_message);
+    }
+
+    pub fn update_esdt_safe_config(
+        &mut self,
+        hash_of_hashes: &ManagedBuffer<StaticApi>,
+        new_config: EsdtSafeConfig<StaticApi>,
+        err_message: Option<&str>,
+        expected_custom_log: Option<&str>,
+    ) {
+        let (result, logs) = self
+            .common_setup
+            .world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(ESDT_SAFE_ADDRESS)
+            .typed(MvxEsdtSafeProxy)
+            .update_esdt_safe_config(hash_of_hashes, new_config)
+            .returns(ReturnsHandledOrError::new())
+            .returns(ReturnsLogs)
+            .run();
+
+        self.common_setup
+            .assert_expected_error_message(result, err_message);
+
+        if let Some(custom_log) = expected_custom_log {
+            self.common_setup.assert_expected_log(logs, custom_log)
+        };
     }
 
     pub fn set_token_burn_mechanism(
@@ -153,7 +180,7 @@ impl MvxEsdtSafeTestState {
         token_id: &str,
         expected_error_message: Option<&str>,
     ) -> &mut Self {
-        let response = self
+        let result = self
             .common_setup
             .world
             .tx()
@@ -165,7 +192,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
 
         self
     }
@@ -175,7 +202,7 @@ impl MvxEsdtSafeTestState {
         token_id: &str,
         expected_error_message: Option<&str>,
     ) -> &mut Self {
-        let response = self
+        let result = self
             .common_setup
             .world
             .tx()
@@ -187,7 +214,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
 
         self
     }
@@ -211,7 +238,7 @@ impl MvxEsdtSafeTestState {
         expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
     ) {
-        let (logs, response) = self
+        let (logs, result) = self
             .common_setup
             .world
             .tx()
@@ -225,7 +252,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
 
         if let Some(custom_log) = expected_custom_log {
             self.common_setup.assert_expected_log(logs, custom_log)
@@ -238,7 +265,7 @@ impl MvxEsdtSafeTestState {
         payment: BigUint<StaticApi>,
         expected_error_message: Option<&str>,
     ) {
-        let response = self
+        let result = self
             .common_setup
             .world
             .tx()
@@ -257,7 +284,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
     }
 
     pub fn register_native_token(
@@ -267,7 +294,7 @@ impl MvxEsdtSafeTestState {
         payment: BigUint<StaticApi>,
         expected_error_message: Option<&str>,
     ) {
-        let response = self
+        let result = self
             .common_setup
             .world
             .tx()
@@ -283,7 +310,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
     }
 
     pub fn execute_operation(
@@ -294,7 +321,7 @@ impl MvxEsdtSafeTestState {
         expected_custom_log: Option<&str>,
         expected_custom_log_data: Option<&str>,
     ) {
-        let (logs, response) = self
+        let (logs, result) = self
             .common_setup
             .world
             .tx()
@@ -307,7 +334,7 @@ impl MvxEsdtSafeTestState {
             .run();
 
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
 
         if let Some(custom_log) = expected_custom_log {
             self.common_setup
@@ -325,7 +352,7 @@ impl MvxEsdtSafeTestState {
         expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
     ) {
-        let (logs, response) = self
+        let (logs, result) = self
             .common_setup
             .world
             .tx()
@@ -337,7 +364,7 @@ impl MvxEsdtSafeTestState {
             .returns(ReturnsHandledOrError::new())
             .run();
         self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+            .assert_expected_error_message(result, expected_error_message);
 
         if let Some(custom_log) = expected_custom_log {
             self.common_setup.assert_expected_log(logs, custom_log)

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -130,7 +130,6 @@ impl MvxEsdtSafeTestState {
 
     pub fn update_configuration(
         &mut self,
-        hash_of_hashes: &ManagedBuffer<StaticApi>,
         new_config: EsdtSafeConfig<StaticApi>,
         err_message: Option<&str>,
     ) {
@@ -141,7 +140,7 @@ impl MvxEsdtSafeTestState {
             .from(OWNER_ADDRESS)
             .to(ESDT_SAFE_ADDRESS)
             .typed(MvxEsdtSafeProxy)
-            .update_esdt_safe_config(hash_of_hashes, new_config)
+            .update_esdt_safe_config_during_setup_phase(new_config)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -12,6 +12,7 @@ use multiversx_sc::{
     },
 };
 use multiversx_sc_modules::transfer_role_proxy::PaymentsVec;
+use multiversx_sc_scenario::ReturnsTxHash;
 use multiversx_sc_scenario::{
     api::StaticApi, ReturnsHandledOrError, ReturnsLogs, ScenarioTxRun, ScenarioTxWhitebox,
 };
@@ -130,6 +131,7 @@ impl MvxEsdtSafeTestState {
 
     pub fn update_configuration(
         &mut self,
+        hash_of_hashes: &ManagedBuffer<StaticApi>,
         new_config: EsdtSafeConfig<StaticApi>,
         err_message: Option<&str>,
     ) {
@@ -140,7 +142,7 @@ impl MvxEsdtSafeTestState {
             .from(OWNER_ADDRESS)
             .to(ESDT_SAFE_ADDRESS)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(new_config)
+            .update_configuration(hash_of_hashes, new_config)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -141,7 +141,7 @@ impl MvxEsdtSafeTestState {
             .from(OWNER_ADDRESS)
             .to(ESDT_SAFE_ADDRESS)
             .typed(MvxEsdtSafeProxy)
-            .update_configuration(hash_of_hashes, new_config)
+            .update_esdt_safe_config(hash_of_hashes, new_config)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -2416,7 +2416,6 @@ fn test_update_config_setup_phase_not_completed() {
 fn test_update_config_operation_not_registered() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
-    // state.common_setup.deploy_chain_config(config)
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -80,7 +80,11 @@ fn test_deploy_invalid_config() {
         ManagedVec::new(),
     );
 
-    state.update_configuration(config, Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED));
+    state.update_configuration(
+        &ManagedBuffer::new(),
+        config,
+        Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED),
+    );
 }
 
 /// ### TEST

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -80,11 +80,7 @@ fn test_deploy_invalid_config() {
         ManagedVec::new(),
     );
 
-    state.update_configuration(
-        &ManagedBuffer::new(),
-        config,
-        Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED),
-    );
+    state.update_configuration(config, Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED));
 }
 
 /// ### TEST

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           13
+// Endpoints:                           14
 // Async Callback (empty):               1
 // Promise callbacks:                    3
-// Total number of exported functions:  19
+// Total number of exported functions:  20
 
 #![no_std]
 
@@ -21,9 +21,10 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateEsdtSafeConfigSetupPhase => update_esdt_safe_config_during_setup_phase
         updateEsdtSafeConfig => update_esdt_safe_config
         setFeeMarketAddress => set_fee_market_address
-        completSetupPhase => complete_setup_phase
+        completeSetupPhase => complete_setup_phase
         deposit => deposit
         executeBridgeOps => execute_operations
         registerToken => register_token

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/src/lib.rs
@@ -21,7 +21,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
-        updateConfiguration => update_configuration
+        updateEsdtSafeConfig => update_esdt_safe_config
         setFeeMarketAddress => set_fee_market_address
         completSetupPhase => complete_setup_phase
         deposit => deposit

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe/src/lib.rs
@@ -6,10 +6,10 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           13
+// Endpoints:                           14
 // Async Callback (empty):               1
 // Promise callbacks:                    3
-// Total number of exported functions:  19
+// Total number of exported functions:  20
 
 #![no_std]
 
@@ -21,9 +21,10 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
+        updateEsdtSafeConfigSetupPhase => update_esdt_safe_config_during_setup_phase
         updateEsdtSafeConfig => update_esdt_safe_config
         setFeeMarketAddress => set_fee_market_address
-        completSetupPhase => complete_setup_phase
+        completeSetupPhase => complete_setup_phase
         deposit => deposit
         executeBridgeOps => execute_operations
         registerToken => register_token

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe/src/lib.rs
@@ -21,7 +21,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     (
         init => init
         upgrade => upgrade
-        updateConfiguration => update_configuration
+        updateEsdtSafeConfig => update_esdt_safe_config
         setFeeMarketAddress => set_fee_market_address
         completSetupPhase => complete_setup_phase
         deposit => deposit

--- a/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/sovereign-forge/wasm-sovereign-forge/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
+++ b/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/token-handler/wasm-token-handler-full/Cargo.lock
+++ b/token-handler/wasm-token-handler-full/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -37,6 +38,18 @@ name = "chain-factory"
 version = "0.1.0"
 dependencies = [
  "chain-config",
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/token-handler/wasm-token-handler-view/Cargo.lock
+++ b/token-handler/wasm-token-handler-view/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -37,6 +38,18 @@ name = "chain-factory"
 version = "0.1.0"
 dependencies = [
  "chain-config",
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",

--- a/token-handler/wasm-token-handler/Cargo.lock
+++ b/token-handler/wasm-token-handler/Cargo.lock
@@ -24,6 +24,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "chain-config"
 version = "0.1.0"
 dependencies = [
+ "cross-chain",
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",
@@ -37,6 +38,18 @@ name = "chain-factory"
 version = "0.1.0"
 dependencies = [
  "chain-config",
+ "error-messages",
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "proxies",
+ "structs",
+ "utils",
+]
+
+[[package]]
+name = "cross-chain"
+version = "0.1.0"
+dependencies = [
  "error-messages",
  "multiversx-sc",
  "multiversx-sc-modules",


### PR DESCRIPTION
Since the configuration updates can be run after the setup-phase completion, the hash of the operation must be registered then locked then removed.

Also added a new trait, `GenerateHash`, that implements a `generate_hash` method. 