### PR TITLE
Common hash locking functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -2669,6 +2670,7 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]
 

--- a/chain-config/Cargo.toml
+++ b/chain-config/Cargo.toml
@@ -35,5 +35,8 @@ path = "../common/error-messages"
 [dependencies.cross-chain]
 path = "../common/cross-chain"
 
+[dependencies.utils]
+path = "../common/utils"
+
 [dev-dependencies.common-test-setup]
 path = "../common/common-test-setup"

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -47,9 +47,8 @@ pub trait ChainConfigContract:
     ) {
         self.require_setup_complete();
 
-        let header_verifier_address = self.blockchain().get_owner_address();
         let config_hash = new_config.generate_hash();
-        self.lock_operation_hash(&header_verifier_address, &config_hash, &hash_of_hashes);
+        self.lock_operation_hash(&config_hash, &hash_of_hashes);
 
         if let Some(error_message) = self.is_new_config_valid(&new_config) {
             self.failed_bridge_operation_event(
@@ -61,7 +60,7 @@ pub trait ChainConfigContract:
             self.sovereign_config().set(new_config);
         }
 
-        self.remove_executed_hash(&header_verifier_address, &hash_of_hashes, &config_hash);
+        self.remove_executed_hash(&hash_of_hashes, &config_hash);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }
 

--- a/chain-config/src/lib.rs
+++ b/chain-config/src/lib.rs
@@ -49,7 +49,7 @@ pub trait ChainConfigContract:
 
         let header_verifier_address = self.blockchain().get_owner_address();
         let config_hash = new_config.generate_hash();
-        self.lock_operation_hash(&config_hash, &hash_of_hashes, &header_verifier_address);
+        self.lock_operation_hash(&header_verifier_address, &config_hash, &hash_of_hashes);
 
         if let Some(error_message) = self.is_new_config_valid(&new_config) {
             self.failed_bridge_operation_event(
@@ -61,7 +61,7 @@ pub trait ChainConfigContract:
             self.sovereign_config().set(new_config);
         }
 
-        self.remove_executed_hash(&hash_of_hashes, &config_hash, &header_verifier_address);
+        self.remove_executed_hash(&header_verifier_address, &hash_of_hashes, &config_hash);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }
 

--- a/chain-config/src/validator_rules.rs
+++ b/chain-config/src/validator_rules.rs
@@ -1,5 +1,4 @@
 use error_messages::INVALID_MIN_MAX_VALIDATOR_NUMBERS;
-use proxies::header_verifier_proxy::HeaderverifierProxy;
 use structs::configs::SovereignConfig;
 
 multiversx_sc::imports!();
@@ -32,22 +31,6 @@ pub trait ValidatorRulesModule {
         } else {
             Some(INVALID_MIN_MAX_VALIDATOR_NUMBERS)
         }
-    }
-
-    fn lock_operation_hash(&self, hash_of_hashes: &ManagedBuffer, hash: &ManagedBuffer) {
-        self.tx()
-            .to(self.blockchain().get_owner_address())
-            .typed(HeaderverifierProxy)
-            .lock_operation_hash(hash_of_hashes, hash)
-            .sync_call();
-    }
-
-    fn remove_executed_hash(&self, hash_of_hashes: &ManagedBuffer, op_hash: &ManagedBuffer) {
-        self.tx()
-            .to(self.blockchain().get_owner_address())
-            .typed(HeaderverifierProxy)
-            .remove_executed_hash(hash_of_hashes, op_hash)
-            .sync_call();
     }
 
     #[view(sovereignConfig)]

--- a/chain-config/tests/chain_config_blackbox_tests.rs
+++ b/chain-config/tests/chain_config_blackbox_tests.rs
@@ -11,6 +11,8 @@ use structs::{configs::SovereignConfig, generate_hash::GenerateHash};
 
 mod chain_config_blackbox_setup;
 
+// TODO: Add change owner functionality after the fix is done in lock_operation_hash endpoint
+
 /// ### TEST
 /// C-CONFIG_DEPLOY_OK
 ///

--- a/chain-config/wasm-chain-config-full/Cargo.lock
+++ b/chain-config/wasm-chain-config-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -275,5 +276,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/chain-config/wasm-chain-config-view/Cargo.lock
+++ b/chain-config/wasm-chain-config-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -275,5 +276,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/chain-config/wasm-chain-config/Cargo.lock
+++ b/chain-config/wasm-chain-config/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -275,5 +276,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/chain-factory/src/factory.rs
+++ b/chain-factory/src/factory.rs
@@ -104,7 +104,7 @@ pub trait FactoryModule: only_admin::OnlyAdminModule {
         let esdt_safe_address = self
             .tx()
             .typed(MvxEsdtSafeProxy)
-            .init(&header_verifier_address, opt_config)
+            .init(opt_config)
             .gas(60_000_000)
             .from_source(source_address)
             .code_metadata(metadata)

--- a/chain-factory/wasm-chain-factory-full/Cargo.lock
+++ b/chain-factory/wasm-chain-factory-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -288,5 +289,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/chain-factory/wasm-chain-factory-view/Cargo.lock
+++ b/chain-factory/wasm-chain-factory-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -288,5 +289,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/chain-factory/wasm-chain-factory/Cargo.lock
+++ b/chain-factory/wasm-chain-factory/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -288,5 +289,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -14,7 +14,8 @@ use multiversx_sc_scenario::{
     api::StaticApi,
     imports::{
         Address, BigUint, EsdtTokenType, ManagedBuffer, MultiValue3, MultiValueEncoded, MxscPath,
-        OptionalValue, TestSCAddress, TestTokenIdentifier, TokenIdentifier, TopEncode, Vec,
+        OptionalValue, ReturnsResultUnmanaged, TestSCAddress, TestTokenIdentifier, TokenIdentifier,
+        TopEncode, UserBuiltinProxy, Vec,
     },
     multiversx_chain_vm::crypto_functions::sha256,
     scenario_model::{Log, TxResponseStatus},
@@ -112,14 +113,13 @@ impl BaseSetup {
 
     pub fn deploy_mvx_esdt_safe(
         &mut self,
-        header_verifier_address: TestSCAddress,
         opt_config: OptionalValue<EsdtSafeConfig<StaticApi>>,
     ) -> &mut Self {
         self.world
             .tx()
             .from(OWNER_ADDRESS)
             .typed(MvxEsdtSafeProxy)
-            .init(header_verifier_address, opt_config)
+            .init(opt_config)
             .code(MVX_ESDT_SAFE_CODE_PATH)
             .new_address(ESDT_SAFE_ADDRESS)
             .run();
@@ -185,6 +185,20 @@ impl BaseSetup {
             .from(OWNER_ADDRESS)
             .to(HEADER_VERIFIER_ADDRESS)
             .typed(HeaderverifierProxy)
+            .complete_setup_phase()
+            .returns(ReturnsHandledOrError::new())
+            .run();
+
+        self.assert_expected_error_message(response, expected_error_message);
+    }
+
+    pub fn complete_sovereign_forge_setup_phase(&mut self, expected_error_message: Option<&str>) {
+        let response = self
+            .world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(SOVEREIGN_FORGE_SC_ADDRESS)
+            .typed(SovereignForgeProxy)
             .complete_setup_phase()
             .returns(ReturnsHandledOrError::new())
             .run();
@@ -393,6 +407,40 @@ impl BaseSetup {
         self.assert_expected_error_message(response, error_message);
     }
 
+    pub fn finish_sovereign_setup_phase(&mut self, expected_error_message: Option<&str>) {
+        let response = self
+            .world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(SOVEREIGN_FORGE_SC_ADDRESS)
+            .typed(SovereignForgeProxy)
+            .complete_setup_phase()
+            .returns(ReturnsHandledOrError::new())
+            .run();
+
+        self.assert_expected_error_message(response, expected_error_message);
+    }
+
+    pub fn deploy_sovereign_chain(
+        &mut self,
+        payment: &BigUint<StaticApi>,
+        opt_preferred_chain: Option<ManagedBuffer<StaticApi>>,
+        opt_sovereign_config: OptionalValue<SovereignConfig<StaticApi>>,
+        opt_esdt_safe_config: OptionalValue<EsdtSafeConfig<StaticApi>>,
+        opt_fee: Option<FeeStruct<StaticApi>>,
+    ) {
+        self.deploy_sovereign_forge();
+        self.deploy_chain_factory();
+        self.deploy_token_handler();
+
+        self.deploy_phase_one(payment, opt_preferred_chain, opt_sovereign_config, None);
+        self.deploy_phase_two(None);
+        self.deploy_phase_three(opt_esdt_safe_config, None);
+        self.deploy_phase_four(opt_fee, None);
+
+        self.finish_sovereign_setup_phase(None);
+    }
+
     pub fn register_operation(
         &mut self,
         caller: CallerAddress,
@@ -446,6 +494,17 @@ impl BaseSetup {
             .run();
 
         self.assert_expected_error_message(response, error_message);
+    }
+
+    pub fn change_ownership_to_header_verifier(&mut self, sc_address: TestSCAddress) {
+        self.world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(sc_address)
+            .typed(UserBuiltinProxy)
+            .change_owner_address(&HEADER_VERIFIER_ADDRESS.to_managed_address())
+            .returns(ReturnsResultUnmanaged)
+            .run();
     }
 
     pub fn get_operation_hash(

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -407,40 +407,6 @@ impl BaseSetup {
         self.assert_expected_error_message(response, error_message);
     }
 
-    pub fn finish_sovereign_setup_phase(&mut self, expected_error_message: Option<&str>) {
-        let response = self
-            .world
-            .tx()
-            .from(OWNER_ADDRESS)
-            .to(SOVEREIGN_FORGE_SC_ADDRESS)
-            .typed(SovereignForgeProxy)
-            .complete_setup_phase()
-            .returns(ReturnsHandledOrError::new())
-            .run();
-
-        self.assert_expected_error_message(response, expected_error_message);
-    }
-
-    pub fn deploy_sovereign_chain(
-        &mut self,
-        payment: &BigUint<StaticApi>,
-        opt_preferred_chain: Option<ManagedBuffer<StaticApi>>,
-        opt_sovereign_config: OptionalValue<SovereignConfig<StaticApi>>,
-        opt_esdt_safe_config: OptionalValue<EsdtSafeConfig<StaticApi>>,
-        opt_fee: Option<FeeStruct<StaticApi>>,
-    ) {
-        self.deploy_sovereign_forge();
-        self.deploy_chain_factory();
-        self.deploy_token_handler();
-
-        self.deploy_phase_one(payment, opt_preferred_chain, opt_sovereign_config, None);
-        self.deploy_phase_two(None);
-        self.deploy_phase_three(opt_esdt_safe_config, None);
-        self.deploy_phase_four(opt_fee, None);
-
-        self.finish_sovereign_setup_phase(None);
-    }
-
     pub fn register_operation(
         &mut self,
         caller: CallerAddress,

--- a/common/cross-chain/src/execute_common.rs
+++ b/common/cross-chain/src/execute_common.rs
@@ -1,20 +1,7 @@
-use error_messages::NO_HEADER_VERIFIER_ADDRESS;
-
 multiversx_sc::imports!();
 
 #[multiversx_sc::module]
 pub trait ExecuteCommonModule: crate::storage::CrossChainStorage {
-    fn get_header_verifier_address(&self) -> ManagedAddress {
-        let header_verifier_address_mapper = self.header_verifier_address();
-
-        require!(
-            !header_verifier_address_mapper.is_empty(),
-            NO_HEADER_VERIFIER_ADDRESS
-        );
-
-        header_verifier_address_mapper.get()
-    }
-
     fn is_native_token(&self, token_identifier: &TokenIdentifier) -> bool {
         let esdt_safe_native_token_mapper = self.native_token();
 

--- a/common/cross-chain/src/execute_common.rs
+++ b/common/cross-chain/src/execute_common.rs
@@ -1,26 +1,9 @@
 use error_messages::NO_HEADER_VERIFIER_ADDRESS;
-use proxies::header_verifier_proxy::HeaderverifierProxy;
 
 multiversx_sc::imports!();
 
 #[multiversx_sc::module]
 pub trait ExecuteCommonModule: crate::storage::CrossChainStorage {
-    fn lock_operation_hash(&self, hash_of_hashes: &ManagedBuffer, hash: &ManagedBuffer) {
-        self.tx()
-            .to(self.get_header_verifier_address())
-            .typed(HeaderverifierProxy)
-            .lock_operation_hash(hash_of_hashes, hash)
-            .sync_call();
-    }
-
-    fn remove_executed_hash(&self, hash_of_hashes: &ManagedBuffer, op_hash: &ManagedBuffer) {
-        self.tx()
-            .to(self.get_header_verifier_address())
-            .typed(HeaderverifierProxy)
-            .remove_executed_hash(hash_of_hashes, op_hash)
-            .sync_call();
-    }
-
     fn get_header_verifier_address(&self) -> ManagedAddress {
         let header_verifier_address_mapper = self.header_verifier_address();
 

--- a/common/cross-chain/src/storage.rs
+++ b/common/cross-chain/src/storage.rs
@@ -13,9 +13,6 @@ pub trait CrossChainStorage {
     #[storage_mapper("feeMarketAddress")]
     fn fee_market_address(&self) -> SingleValueMapper<ManagedAddress>;
 
-    #[storage_mapper("headerVerifierAddress")]
-    fn header_verifier_address(&self) -> SingleValueMapper<ManagedAddress>;
-
     #[storage_mapper("sovToMxTokenId")]
     fn sovereign_to_multiversx_token_id_mapper(
         &self,

--- a/common/proxies/src/enshrine_esdt_safe_proxy.rs
+++ b/common/proxies/src/enshrine_esdt_safe_proxy.rs
@@ -123,19 +123,6 @@ where
             .original_result()
     }
 
-    pub fn set_header_verifier_address<
-        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-    >(
-        self,
-        header_verifier_address: Arg0,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("setHeaderVerifierAddress")
-            .argument(&header_verifier_address)
-            .original_result()
-    }
-
     pub fn deposit<
         Arg0: ProxyArg<ManagedAddress<Env::Api>>,
         Arg1: ProxyArg<OptionalValue<MultiValue3<u64, ManagedBuffer<Env::Api>, MultiValueEncoded<Env::Api, ManagedBuffer<Env::Api>>>>>,

--- a/common/proxies/src/mvx_esdt_safe_proxy.rs
+++ b/common/proxies/src/mvx_esdt_safe_proxy.rs
@@ -44,17 +44,14 @@ where
     Gas: TxGas<Env>,
 {
     pub fn init<
-        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-        Arg1: ProxyArg<OptionalValue<structs::configs::EsdtSafeConfig<Env::Api>>>,
+        Arg0: ProxyArg<OptionalValue<structs::configs::EsdtSafeConfig<Env::Api>>>,
     >(
         self,
-        header_verifier_address: Arg0,
-        opt_config: Arg1,
+        opt_config: Arg0,
     ) -> TxTypedDeploy<Env, From, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_deploy()
-            .argument(&header_verifier_address)
             .argument(&opt_config)
             .original_result()
     }

--- a/common/utils/Cargo.toml
+++ b/common/utils/Cargo.toml
@@ -13,6 +13,9 @@ path = "../structs"
 [dependencies.error-messages]
 path = "../error-messages"
 
+[dependencies.proxies]
+path = "../proxies"
+
 [dependencies.multiversx-sc]
 version = "=0.57.1"
 features = ["esdt-token-payment-legacy-decode"]

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -13,27 +13,17 @@ const MAX_TOKEN_ID_LEN: usize = 32;
 
 #[multiversx_sc::module]
 pub trait UtilsModule {
-    fn lock_operation_hash(
-        &self,
-        header_verifier_address: &ManagedAddress,
-        hash_of_hashes: &ManagedBuffer,
-        hash: &ManagedBuffer,
-    ) {
+    fn lock_operation_hash(&self, hash_of_hashes: &ManagedBuffer, hash: &ManagedBuffer) {
         self.tx()
-            .to(header_verifier_address)
+            .to(self.blockchain().get_owner_address())
             .typed(HeaderverifierProxy)
             .lock_operation_hash(hash_of_hashes, hash)
             .sync_call();
     }
 
-    fn remove_executed_hash(
-        &self,
-        header_verifier_address: &ManagedAddress,
-        hash_of_hashes: &ManagedBuffer,
-        op_hash: &ManagedBuffer,
-    ) {
+    fn remove_executed_hash(&self, hash_of_hashes: &ManagedBuffer, op_hash: &ManagedBuffer) {
         self.tx()
-            .to(header_verifier_address)
+            .to(self.blockchain().get_owner_address())
             .typed(HeaderverifierProxy)
             .remove_executed_hash(hash_of_hashes, op_hash)
             .sync_call();

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -15,9 +15,9 @@ const MAX_TOKEN_ID_LEN: usize = 32;
 pub trait UtilsModule {
     fn lock_operation_hash(
         &self,
+        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         hash: &ManagedBuffer,
-        header_verifier_address: &ManagedAddress,
     ) {
         self.tx()
             .to(header_verifier_address)
@@ -28,9 +28,9 @@ pub trait UtilsModule {
 
     fn remove_executed_hash(
         &self,
+        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         op_hash: &ManagedBuffer,
-        header_verifier_address: &ManagedAddress,
     ) {
         self.tx()
             .to(header_verifier_address)

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -3,6 +3,7 @@
 use error_messages::{
     ERR_EMPTY_PAYMENTS, INVALID_SC_ADDRESS, INVALID_TOKEN_ID, ITEM_NOT_IN_LIST, TOKEN_ID_NO_PREFIX,
 };
+use proxies::header_verifier_proxy::HeaderverifierProxy;
 use structs::aliases::PaymentsVec;
 
 multiversx_sc::imports!();
@@ -12,6 +13,32 @@ const MAX_TOKEN_ID_LEN: usize = 32;
 
 #[multiversx_sc::module]
 pub trait UtilsModule {
+    fn lock_operation_hash(
+        &self,
+        hash_of_hashes: &ManagedBuffer,
+        hash: &ManagedBuffer,
+        header_verifier_address: &ManagedAddress,
+    ) {
+        self.tx()
+            .to(header_verifier_address)
+            .typed(HeaderverifierProxy)
+            .lock_operation_hash(hash_of_hashes, hash)
+            .sync_call();
+    }
+
+    fn remove_executed_hash(
+        &self,
+        hash_of_hashes: &ManagedBuffer,
+        op_hash: &ManagedBuffer,
+        header_verifier_address: &ManagedAddress,
+    ) {
+        self.tx()
+            .to(header_verifier_address)
+            .typed(HeaderverifierProxy)
+            .remove_executed_hash(hash_of_hashes, op_hash)
+            .sync_call();
+    }
+
     fn require_sc_address(&self, address: &ManagedAddress) {
         require!(
             !address.is_zero() && self.blockchain().is_smart_contract(address),

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -49,8 +49,8 @@ pub trait TransferTokensModule:
 
         let op_hash = operation.generate_hash();
 
-        let header_verifier_address = self.get_header_verifier_address();
-        self.lock_operation_hash(&hash_of_hashes, &op_hash, &header_verifier_address);
+        let header_verifier_address = self.blockchain().get_owner_address();
+        self.lock_operation_hash(&header_verifier_address, &hash_of_hashes, &op_hash);
 
         let split_result = self.split_payments_for_prefix_and_fee(&operation.tokens);
         if !split_result.are_tokens_registered {
@@ -78,7 +78,7 @@ pub trait TransferTokensModule:
             .multi_esdt(split_result.sov_tokens)
             .sync_call();
 
-        self.remove_executed_hash(&hash_of_hashes, &op_hash, &header_verifier_address);
+        self.remove_executed_hash(&header_verifier_address, &hash_of_hashes, &op_hash);
         self.execute_bridge_operation_event(hash_of_hashes, op_hash);
     }
 

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -49,7 +49,8 @@ pub trait TransferTokensModule:
 
         let op_hash = operation.generate_hash();
 
-        self.lock_operation_hash(&hash_of_hashes, &op_hash);
+        let header_verifier_address = self.get_header_verifier_address();
+        self.lock_operation_hash(&hash_of_hashes, &op_hash, &header_verifier_address);
 
         let split_result = self.split_payments_for_prefix_and_fee(&operation.tokens);
         if !split_result.are_tokens_registered {
@@ -77,7 +78,7 @@ pub trait TransferTokensModule:
             .multi_esdt(split_result.sov_tokens)
             .sync_call();
 
-        self.remove_executed_hash(&hash_of_hashes, &op_hash);
+        self.remove_executed_hash(&hash_of_hashes, &op_hash, &header_verifier_address);
         self.execute_bridge_operation_event(hash_of_hashes, op_hash);
     }
 

--- a/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
+++ b/enshrine-esdt-safe/src/from_sovereign/transfer_tokens.rs
@@ -49,8 +49,7 @@ pub trait TransferTokensModule:
 
         let op_hash = operation.generate_hash();
 
-        let header_verifier_address = self.blockchain().get_owner_address();
-        self.lock_operation_hash(&header_verifier_address, &hash_of_hashes, &op_hash);
+        self.lock_operation_hash(&hash_of_hashes, &op_hash);
 
         let split_result = self.split_payments_for_prefix_and_fee(&operation.tokens);
         if !split_result.are_tokens_registered {
@@ -78,7 +77,7 @@ pub trait TransferTokensModule:
             .multi_esdt(split_result.sov_tokens)
             .sync_call();
 
-        self.remove_executed_hash(&header_verifier_address, &hash_of_hashes, &op_hash);
+        self.remove_executed_hash(&hash_of_hashes, &op_hash);
         self.execute_bridge_operation_event(hash_of_hashes, op_hash);
     }
 

--- a/enshrine-esdt-safe/src/lib.rs
+++ b/enshrine-esdt-safe/src/lib.rs
@@ -50,7 +50,7 @@ pub trait EnshrineEsdtSafe:
                 self.wegld_identifier().set(identifier);
             }
 
-            None => sc_panic!("WEGLG identifier must be set in Mainchain"),
+            None => sc_panic!("WEGLD identifier must be set in Mainchain"),
         }
 
         match opt_sov_token_prefix {
@@ -77,14 +77,6 @@ pub trait EnshrineEsdtSafe:
         self.require_sc_address(&fee_market_address);
 
         self.fee_market_address().set(fee_market_address);
-    }
-
-    #[only_owner]
-    #[endpoint(setHeaderVerifierAddress)]
-    fn set_header_verifier_address(&self, header_verifier_address: ManagedAddress) {
-        self.require_sc_address(&header_verifier_address);
-
-        self.header_verifier_address().set(&header_verifier_address);
     }
 
     #[upgrade]

--- a/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_setup.rs
+++ b/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_setup.rs
@@ -1,10 +1,9 @@
 use common_test_setup::{
     constants::{
         CHAIN_CONFIG_ADDRESS, CHAIN_FACTORY_SC_ADDRESS, CROWD_TOKEN_ID, ENSHRINE_BALANCE,
-        ENSHRINE_SC_ADDRESS, FEE_MARKET_ADDRESS, FUNGIBLE_TOKEN_ID, HEADER_VERIFIER_ADDRESS,
-        INSUFFICIENT_WEGLD_ADDRESS, NFT_TOKEN_ID, OWNER_ADDRESS, OWNER_BALANCE,
-        PREFIX_NFT_TOKEN_ID, RECEIVER_ADDRESS, SOVEREIGN_TOKEN_PREFIX, TOKEN_HANDLER_SC_ADDRESS,
-        USER_ADDRESS, WEGLD_IDENTIFIER,
+        ENSHRINE_SC_ADDRESS, FEE_MARKET_ADDRESS, FUNGIBLE_TOKEN_ID, INSUFFICIENT_WEGLD_ADDRESS,
+        NFT_TOKEN_ID, OWNER_ADDRESS, OWNER_BALANCE, PREFIX_NFT_TOKEN_ID, RECEIVER_ADDRESS,
+        SOVEREIGN_TOKEN_PREFIX, TOKEN_HANDLER_SC_ADDRESS, USER_ADDRESS, WEGLD_IDENTIFIER,
     },
     AccountSetup, BaseSetup,
 };
@@ -101,17 +100,6 @@ impl EnshrineTestState {
             .run();
     }
 
-    pub fn set_header_verifier_address(&mut self) {
-        self.common_setup
-            .world
-            .tx()
-            .from(OWNER_ADDRESS)
-            .to(ENSHRINE_SC_ADDRESS)
-            .typed(EnshrineEsdtSafeProxy)
-            .set_header_verifier_address(HEADER_VERIFIER_ADDRESS)
-            .run();
-    }
-
     pub fn setup_contracts(
         &mut self,
         is_sovereign_chain: bool,
@@ -133,9 +121,10 @@ impl EnshrineTestState {
         self.common_setup.deploy_token_handler();
         self.common_setup
             .deploy_fee_market(fee_struct.cloned(), ENSHRINE_SC_ADDRESS);
-        self.set_header_verifier_address();
         self.register_fee_market_address();
         self.common_setup.deploy_chain_factory();
+        self.common_setup
+            .change_ownership_to_header_verifier(ENSHRINE_SC_ADDRESS);
 
         self
     }

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -353,5 +354,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/src/lib.rs
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           16
+// Endpoints:                           15
 // Async Callback:                       1
-// Total number of exported functions:  19
+// Total number of exported functions:  18
 
 #![no_std]
 
@@ -22,7 +22,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
-        setHeaderVerifierAddress => set_header_verifier_address
         deposit => deposit
         executeBridgeOps => execute_operations
         registerNewTokenID => register_new_token_id

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -353,5 +354,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -353,5 +354,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe/src/lib.rs
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           16
+// Endpoints:                           15
 // Async Callback:                       1
-// Total number of exported functions:  19
+// Total number of exported functions:  18
 
 #![no_std]
 
@@ -22,7 +22,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         updateConfiguration => update_configuration
         setFeeMarketAddress => set_fee_market_address
-        setHeaderVerifierAddress => set_header_verifier_address
         deposit => deposit
         executeBridgeOps => execute_operations
         registerNewTokenID => register_new_token_id

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -1,6 +1,6 @@
 use common_test_setup::constants::{
-    ESDT_SAFE_ADDRESS, FIRST_TEST_TOKEN, OWNER_BALANCE, SECOND_TEST_TOKEN, USER_ADDRESS,
-    WRONG_TOKEN_ID,
+    ESDT_SAFE_ADDRESS, FEE_MARKET_ADDRESS, FIRST_TEST_TOKEN, OWNER_BALANCE, SECOND_TEST_TOKEN,
+    USER_ADDRESS, WRONG_TOKEN_ID,
 };
 use error_messages::{
     INVALID_FEE, INVALID_FEE_TYPE, INVALID_TOKEN_ID, PAYMENT_DOES_NOT_COVER_FEE,
@@ -177,6 +177,9 @@ fn test_substract_fixed_fee_payment_not_covered() {
     state
         .common_setup
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(FEE_MARKET_ADDRESS);
 
     state.substract_fee("Less than fee", Some(PAYMENT_DOES_NOT_COVER_FEE));
 
@@ -212,6 +215,9 @@ fn test_substract_fee_fixed_payment_bigger_than_fee() {
     state
         .common_setup
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(FEE_MARKET_ADDRESS);
 
     state.substract_fee("Correct", None);
 

--- a/fee-market/wasm-fee-market-view/Cargo.lock
+++ b/fee-market/wasm-fee-market-view/Cargo.lock
@@ -253,5 +253,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/fee-market/wasm-fee-market/Cargo.lock
+++ b/fee-market/wasm-fee-market/Cargo.lock
@@ -253,5 +253,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/header-verifier/wasm-header-verifier-full/Cargo.lock
+++ b/header-verifier/wasm-header-verifier-full/Cargo.lock
@@ -274,5 +274,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/header-verifier/wasm-header-verifier-view/Cargo.lock
+++ b/header-verifier/wasm-header-verifier-view/Cargo.lock
@@ -274,5 +274,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/header-verifier/wasm-header-verifier/Cargo.lock
+++ b/header-verifier/wasm-header-verifier/Cargo.lock
@@ -274,5 +274,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/interactor/src/enshrine_esdt_safe/enshrine_esdt_safe_interactor.rs
+++ b/interactor/src/enshrine_esdt_safe/enshrine_esdt_safe_interactor.rs
@@ -102,25 +102,6 @@ impl EnshrineEsdtSafeInteract {
         println!("Result: {response:?}");
     }
 
-    pub async fn set_header_verifier_address_in_enshrine_esdt_safe(
-        &mut self,
-        header_verifier_address: Bech32Address,
-    ) {
-        let response = self
-            .interactor
-            .tx()
-            .from(&self.wallet_address)
-            .to(self.state.current_enshrine_esdt_safe_address())
-            .gas(30_000_000u64)
-            .typed(EnshrineEsdtSafeProxy)
-            .set_header_verifier_address(header_verifier_address)
-            .returns(ReturnsResultUnmanaged)
-            .run()
-            .await;
-
-        println!("Result: {response:?}");
-    }
-
     pub async fn deposit(
         &mut self,
         payments: PaymentsVec<StaticApi>,

--- a/interactor/src/interact.rs
+++ b/interactor/src/interact.rs
@@ -38,12 +38,7 @@ pub async fn mvx_esdt_safe_cli() {
                 .await
         }
         "deployEsdtSafe" => {
-            interact
-                .deploy_mvx_esdt_safe(
-                    interact.state.current_header_verifier_address().clone(),
-                    OptionalValue::None,
-                )
-                .await;
+            interact.deploy_mvx_esdt_safe(OptionalValue::None).await;
         }
         "deployFeeMarket" => {
             interact
@@ -110,14 +105,7 @@ pub async fn sovereign_forge_cli() {
                 .deploy_header_verifier(interact.state.current_chain_config_sc_address().clone())
                 .await
         }
-        "deployEsdtSafe" => {
-            interact
-                .deploy_mvx_esdt_safe(
-                    interact.state.current_header_verifier_address().clone(),
-                    OptionalValue::None,
-                )
-                .await
-        }
+        "deployEsdtSafe" => interact.deploy_mvx_esdt_safe(OptionalValue::None).await,
         "deployFeeMarket" => {
             interact
                 .deploy_fee_market(
@@ -174,13 +162,6 @@ pub async fn enshrine_esdt_safe_cli() {
             interact
                 .set_fee_market_address_in_enshrine_esdt_safe(
                     interact.state.current_fee_market_address().clone(),
-                )
-                .await
-        }
-        "setHeaderVerifierAddress" => {
-            interact
-                .set_header_verifier_address_in_enshrine_esdt_safe(
-                    interact.state.current_header_verifier_address().clone(),
                 )
                 .await
         }

--- a/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
+++ b/interactor/src/mvx_esdt_safe/mvx_esdt_safe_interactor_main.rs
@@ -198,12 +198,7 @@ impl MvxEsdtSafeInteract {
         self.deploy_header_verifier(self.state.current_chain_config_sc_address().clone())
             .await;
         self.complete_header_verifier_setup_phase().await;
-        self.deploy_mvx_esdt_safe(
-            self.state.current_header_verifier_address().clone(),
-            esdt_safe_config,
-        )
-        .await;
-        self.complete_setup_phase().await;
+        self.deploy_mvx_esdt_safe(esdt_safe_config).await;
         self.deploy_fee_market(
             self.state.current_mvx_esdt_safe_contract_address().clone(),
             fee_struct,
@@ -211,6 +206,7 @@ impl MvxEsdtSafeInteract {
         .await;
         self.set_fee_market_address(self.state.current_fee_market_address().to_address())
             .await;
+        self.complete_setup_phase().await;
     }
 
     pub async fn register_operation(
@@ -248,6 +244,14 @@ impl MvxEsdtSafeInteract {
             .returns(ReturnsResultUnmanaged)
             .run()
             .await;
+
+        self.change_ownership_to_header_verifier(
+            self.owner_address.clone(),
+            self.state
+                .current_mvx_esdt_safe_contract_address()
+                .to_address(),
+        )
+        .await;
     }
 
     pub async fn upgrade(&mut self) {

--- a/interactor/tests/mvx_esdt_safe_tests.rs
+++ b/interactor/tests/mvx_esdt_safe_tests.rs
@@ -524,13 +524,7 @@ async fn register_token_invalid_type_token() {
         .await;
 
     chain_interactor
-        .deploy_mvx_esdt_safe(
-            chain_interactor
-                .state
-                .current_header_verifier_address()
-                .clone(),
-            OptionalValue::Some(EsdtSafeConfig::default_config()),
-        )
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()))
         .await;
 
     let sov_token_id = TokenIdentifier::from_esdt_bytes(SOV_TOKEN.as_str());
@@ -596,13 +590,7 @@ async fn register_token_fungible_token() {
         .await;
 
     chain_interactor
-        .deploy_mvx_esdt_safe(
-            chain_interactor
-                .state
-                .current_header_verifier_address()
-                .clone(),
-            OptionalValue::Some(EsdtSafeConfig::default_config()),
-        )
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()))
         .await;
 
     let sov_token_id = TokenIdentifier::from_esdt_bytes(SOV_TOKEN.as_str());
@@ -670,13 +658,7 @@ async fn register_token_non_fungible_token() {
         .await;
 
     chain_interactor
-        .deploy_mvx_esdt_safe(
-            chain_interactor
-                .state
-                .current_header_verifier_address()
-                .clone(),
-            OptionalValue::Some(EsdtSafeConfig::default_config()),
-        )
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()))
         .await;
 
     let sov_token_id = TokenIdentifier::from_esdt_bytes(SOV_TOKEN.as_str());
@@ -744,13 +726,7 @@ async fn register_token_dynamic_non_fungible_token() {
         .await;
 
     chain_interactor
-        .deploy_mvx_esdt_safe(
-            chain_interactor
-                .state
-                .current_header_verifier_address()
-                .clone(),
-            OptionalValue::Some(EsdtSafeConfig::default_config()),
-        )
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()))
         .await;
 
     let sov_token_id = TokenIdentifier::from_esdt_bytes(SOV_TOKEN.as_str());
@@ -818,13 +794,7 @@ async fn execute_operation_no_esdt_safe_registered() {
         .await;
 
     chain_interactor
-        .deploy_mvx_esdt_safe(
-            chain_interactor
-                .state
-                .current_header_verifier_address()
-                .clone(),
-            OptionalValue::Some(EsdtSafeConfig::default_config()),
-        )
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()))
         .await;
 
     chain_interactor.unpause_endpoint().await;

--- a/interactor/tests/sovereign_forge_tests.rs
+++ b/interactor/tests/sovereign_forge_tests.rs
@@ -34,9 +34,7 @@ async fn deploy_test_sovereign_forge_cs() {
         .await;
     let header_verifier_address = interactor.state.current_header_verifier_address().clone();
 
-    interactor
-        .deploy_mvx_esdt_safe(header_verifier_address.clone(), OptionalValue::None)
-        .await;
+    interactor.deploy_mvx_esdt_safe(OptionalValue::None).await;
     let mvx_esdt_safe_address = interactor
         .state
         .current_mvx_esdt_safe_contract_address()

--- a/mvx-esdt-safe/src/execute.rs
+++ b/mvx-esdt-safe/src/execute.rs
@@ -28,8 +28,7 @@ pub trait ExecuteModule:
 
         let operation_hash = operation.generate_hash();
 
-        let header_verifier_address = self.blockchain().get_owner_address();
-        self.lock_operation_hash(&header_verifier_address, &hash_of_hashes, &operation_hash);
+        self.lock_operation_hash(&hash_of_hashes, &operation_hash);
 
         let operation_tuple = OperationTuple {
             op_hash: operation_hash,
@@ -37,26 +36,18 @@ pub trait ExecuteModule:
         };
 
         if operation.tokens.is_empty() {
-            self.execute_sc_call(&header_verifier_address, &hash_of_hashes, &operation_tuple);
+            self.execute_sc_call(&hash_of_hashes, &operation_tuple);
 
             return;
         }
 
-        if let Some(minted_operation_tokens) =
-            self.mint_tokens(&header_verifier_address, &hash_of_hashes, &operation_tuple)
-        {
-            self.distribute_payments(
-                &header_verifier_address,
-                &hash_of_hashes,
-                &operation_tuple,
-                &minted_operation_tokens,
-            );
+        if let Some(minted_operation_tokens) = self.mint_tokens(&hash_of_hashes, &operation_tuple) {
+            self.distribute_payments(&hash_of_hashes, &operation_tuple, &minted_operation_tokens);
         }
     }
 
     fn mint_tokens(
         &self,
-        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         operation_tuple: &OperationTuple<Self::Api>,
     ) -> Option<ManagedVec<OperationEsdtPayment<Self::Api>>> {
@@ -70,7 +61,6 @@ pub trait ExecuteModule:
                 }
                 None => {
                     if let Some(payment) = self.process_unresolved_token(
-                        header_verifier_address,
                         hash_of_hashes,
                         operation_tuple,
                         &operation_token,
@@ -106,7 +96,6 @@ pub trait ExecuteModule:
 
     fn process_unresolved_token(
         &self,
-        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         operation_tuple: &OperationTuple<Self::Api>,
         operation_token: &OperationEsdtPayment<Self::Api>,
@@ -121,11 +110,7 @@ pub trait ExecuteModule:
 
             if operation_token.token_data.amount > deposited_amount {
                 self.emit_transfer_failed_events(hash_of_hashes, operation_tuple);
-                self.remove_executed_hash(
-                    header_verifier_address,
-                    hash_of_hashes,
-                    &operation_tuple.op_hash,
-                );
+                self.remove_executed_hash(hash_of_hashes, &operation_tuple.op_hash);
 
                 return None;
             }
@@ -212,7 +197,6 @@ pub trait ExecuteModule:
 
     fn distribute_payments(
         &self,
-        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         operation_tuple: &OperationTuple<Self::Api>,
         tokens_list: &ManagedVec<OperationEsdtPayment<Self::Api>>,
@@ -232,11 +216,10 @@ pub trait ExecuteModule:
                     .arguments_raw(args)
                     .payment(&mapped_tokens)
                     .gas(transfer_data.gas_limit)
-                    .callback(<Self as ExecuteModule>::callbacks(self).execute(
-                        header_verifier_address,
-                        hash_of_hashes,
-                        operation_tuple,
-                    ))
+                    .callback(
+                        <Self as ExecuteModule>::callbacks(self)
+                            .execute(hash_of_hashes, operation_tuple),
+                    )
                     .gas_for_callback(CALLBACK_GAS)
                     .register_promise();
             }
@@ -245,11 +228,10 @@ pub trait ExecuteModule:
                     .to(&operation_tuple.operation.to)
                     .multi_esdt(mapped_tokens)
                     .gas(ESDT_TRANSACTION_GAS)
-                    .callback(<Self as ExecuteModule>::callbacks(self).execute(
-                        header_verifier_address,
-                        hash_of_hashes,
-                        operation_tuple,
-                    ))
+                    .callback(
+                        <Self as ExecuteModule>::callbacks(self)
+                            .execute(hash_of_hashes, operation_tuple),
+                    )
                     .gas_for_callback(CALLBACK_GAS)
                     .register_promise();
             }
@@ -258,7 +240,6 @@ pub trait ExecuteModule:
 
     fn execute_sc_call(
         &self,
-        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         operation_tuple: &OperationTuple<Self::Api>,
     ) {
@@ -275,11 +256,9 @@ pub trait ExecuteModule:
             .raw_call(transfer_data.function.clone())
             .arguments_raw(args)
             .gas(transfer_data.gas_limit)
-            .callback(<Self as ExecuteModule>::callbacks(self).execute(
-                header_verifier_address,
-                hash_of_hashes,
-                operation_tuple,
-            ))
+            .callback(
+                <Self as ExecuteModule>::callbacks(self).execute(hash_of_hashes, operation_tuple),
+            )
             .gas_for_callback(CALLBACK_GAS)
             .register_promise();
     }
@@ -287,7 +266,6 @@ pub trait ExecuteModule:
     #[promises_callback]
     fn execute(
         &self,
-        header_verifier_address: &ManagedAddress,
         hash_of_hashes: &ManagedBuffer,
         operation_tuple: &OperationTuple<Self::Api>,
         #[call_result] result: ManagedAsyncCallResult<IgnoreValue>,
@@ -301,11 +279,7 @@ pub trait ExecuteModule:
             }
         }
 
-        self.remove_executed_hash(
-            header_verifier_address,
-            hash_of_hashes,
-            &operation_tuple.op_hash,
-        );
+        self.remove_executed_hash(hash_of_hashes, &operation_tuple.op_hash);
     }
 
     fn emit_transfer_failed_events(

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -63,9 +63,8 @@ pub trait MvxEsdtSafe:
     ) {
         self.require_setup_complete();
 
-        let header_verifier_address = self.blockchain().get_owner_address();
         let config_hash = new_config.generate_hash();
-        self.lock_operation_hash(&header_verifier_address, &hash_of_hashes, &config_hash);
+        self.lock_operation_hash(&hash_of_hashes, &config_hash);
 
         if let Some(error_message) = self.is_esdt_safe_config_valid(&new_config) {
             self.failed_bridge_operation_event(
@@ -77,7 +76,7 @@ pub trait MvxEsdtSafe:
             self.esdt_safe_config().set(new_config);
         }
 
-        self.remove_executed_hash(&header_verifier_address, &hash_of_hashes, &config_hash);
+        self.remove_executed_hash(&hash_of_hashes, &config_hash);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }
 

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -70,8 +70,9 @@ pub trait MvxEsdtSafe:
     ) {
         self.require_setup_complete();
 
+        let header_verifier_address = self.get_header_verifier_address();
         let config_hash = new_config.generate_hash();
-        self.lock_operation_hash(&hash_of_hashes, &config_hash);
+        self.lock_operation_hash(&hash_of_hashes, &config_hash, &header_verifier_address);
 
         if let Some(error_message) = self.is_esdt_safe_config_valid(&new_config) {
             self.failed_bridge_operation_event(
@@ -83,7 +84,7 @@ pub trait MvxEsdtSafe:
             self.esdt_safe_config().set(new_config);
         }
 
-        self.remove_executed_hash(&hash_of_hashes, &config_hash);
+        self.remove_executed_hash(&hash_of_hashes, &config_hash, &header_verifier_address);
         self.execute_bridge_operation_event(&hash_of_hashes, &config_hash);
     }
 

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -110,10 +110,7 @@ impl MvxEsdtSafeTestState {
                     ManagedVec::new(),
                 );
 
-                sc.init(
-                    HEADER_VERIFIER_ADDRESS.to_managed_address(),
-                    OptionalValue::Some(config),
-                );
+                sc.init(OptionalValue::Some(config));
             });
 
         self.common_setup
@@ -183,7 +180,7 @@ impl MvxEsdtSafeTestState {
             .common_setup
             .world
             .tx()
-            .from(OWNER_ADDRESS)
+            .from(HEADER_VERIFIER_ADDRESS)
             .to(ESDT_SAFE_ADDRESS)
             .typed(MvxEsdtSafeProxy)
             .set_token_burn_mechanism(TokenIdentifier::from(token_id))
@@ -205,7 +202,7 @@ impl MvxEsdtSafeTestState {
             .common_setup
             .world
             .tx()
-            .from(OWNER_ADDRESS)
+            .from(HEADER_VERIFIER_ADDRESS)
             .to(ESDT_SAFE_ADDRESS)
             .typed(MvxEsdtSafeProxy)
             .set_token_lock_mechanism(TokenIdentifier::from(token_id))
@@ -359,6 +356,34 @@ impl MvxEsdtSafeTestState {
             .returns(ReturnsLogs)
             .returns(ReturnsHandledOrError::new())
             .run();
+
+        self.common_setup
+            .assert_expected_error_message(result, expected_error_message);
+
+        self.common_setup
+            .assert_expected_log(logs, expected_custom_log);
+
+        self.common_setup
+            .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
+    }
+
+    pub fn complete_setup_phase_as_header_verifier(
+        &mut self,
+        expected_error_message: Option<&str>,
+        expected_custom_log: Option<&str>,
+    ) {
+        let (logs, result) = self
+            .common_setup
+            .world
+            .tx()
+            .from(HEADER_VERIFIER_ADDRESS)
+            .to(ESDT_SAFE_ADDRESS)
+            .typed(MvxEsdtSafeProxy)
+            .complete_setup_phase()
+            .returns(ReturnsLogs)
+            .returns(ReturnsHandledOrError::new())
+            .run();
+
         self.common_setup
             .assert_expected_error_message(result, expected_error_message);
 

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -50,10 +50,9 @@ mod mvx_esdt_safe_blackbox_setup;
 fn test_deploy() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state
+        .common_setup
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()));
 }
 
 /// ### TEST
@@ -68,10 +67,9 @@ fn test_deploy() {
 fn test_deploy_invalid_config() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state
+        .common_setup
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()));
 
     let config = EsdtSafeConfig::new(
         ManagedVec::new(),
@@ -95,10 +93,7 @@ fn test_deploy_invalid_config() {
 #[test]
 fn test_register_token_invalid_type() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, config);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = FIRST_TEST_TOKEN;
     let token_type = EsdtTokenType::Invalid;
@@ -137,10 +132,7 @@ fn test_register_token_invalid_type() {
 #[test]
 fn test_register_token_invalid_type_with_prefix() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = SOV_TOKEN;
     let token_type = EsdtTokenType::Invalid;
@@ -175,10 +167,7 @@ fn test_register_token_invalid_type_with_prefix() {
 #[test]
 fn test_register_token_not_native() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = SECOND_TEST_TOKEN;
     let token_type = EsdtTokenType::Fungible;
@@ -217,10 +206,7 @@ fn test_register_token_not_native() {
 #[test]
 fn test_register_token_fungible_token() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = SOV_TOKEN;
     let token_type = EsdtTokenType::Fungible;
@@ -253,10 +239,7 @@ fn test_register_token_fungible_token() {
 #[test]
 fn test_register_token_nonfungible_token() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = FIRST_TEST_TOKEN;
     let token_type = EsdtTokenType::NonFungible;
@@ -296,15 +279,12 @@ fn test_register_token_nonfungible_token() {
 fn test_deposit_nothing_to_transfer() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.deposit(
         USER_ADDRESS.to_managed_address(),
@@ -331,10 +311,7 @@ fn test_deposit_nothing_to_transfer() {
 fn test_complete_setup_phase() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let token_display_name = "TokenOne";
     let egld_payment = BigUint::from(DEFAULT_ISSUE_COST);
@@ -369,10 +346,10 @@ fn test_complete_setup_phase() {
 fn test_complete_setup_phase_already_completed() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
 
     state.complete_setup_phase(None, Some("unpauseContract"));
     state
@@ -384,7 +361,7 @@ fn test_complete_setup_phase_already_completed() {
             assert!(sc.is_setup_phase_complete());
         });
 
-    state.complete_setup_phase(Some(SETUP_PHASE_ALREADY_COMPLETED), None);
+    state.complete_setup_phase_as_header_verifier(Some(SETUP_PHASE_ALREADY_COMPLETED), None);
 }
 
 /// ### TEST
@@ -399,11 +376,7 @@ fn test_complete_setup_phase_already_completed() {
 fn test_deposit_too_many_tokens() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
@@ -413,6 +386,7 @@ fn test_deposit_too_many_tokens() {
         0,
         BigUint::default(),
     );
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let payments_vec = PaymentsVec::from(vec![esdt_token_payment; 11]);
 
@@ -444,15 +418,12 @@ fn test_deposit_too_many_tokens() {
 fn test_deposit_no_transfer_data() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -507,13 +478,14 @@ fn test_deposit_gas_limit_too_high() {
     );
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
+
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
     state.common_setup.deploy_testing_sc();
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -581,13 +553,14 @@ fn test_deposit_max_bridged_amount_exceeded() {
 
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
+
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -643,13 +616,16 @@ fn test_deposit_endpoint_banned() {
 
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -704,17 +680,14 @@ fn test_deposit_endpoint_banned() {
 fn test_deposit_no_transfer_data_no_fee() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.deposit(
         USER_ADDRESS.to_managed_address(),
@@ -737,17 +710,14 @@ fn test_deposit_no_transfer_data_no_fee() {
 fn test_deposit_transfer_data_only_no_fee() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let gas_limit = 2;
     let function = ManagedBuffer::<StaticApi>::from("hello");
@@ -779,11 +749,10 @@ fn test_deposit_transfer_data_only_no_fee() {
 fn test_deposit_transfer_data_only_with_fee_nothing_to_transfer() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -802,6 +771,7 @@ fn test_deposit_transfer_data_only_with_fee_nothing_to_transfer() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let gas_limit = 2;
     let function = ManagedBuffer::<StaticApi>::from("hello");
@@ -833,11 +803,10 @@ fn test_deposit_transfer_data_only_with_fee_nothing_to_transfer() {
 fn test_deposit_transfer_data_only_with_fee() {
     let mut state = MvxEsdtSafeTestState::new();
 
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -863,6 +832,7 @@ fn test_deposit_transfer_data_only_with_fee() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let gas_limit = 2;
     let function = ManagedBuffer::<StaticApi>::from("hello");
@@ -911,8 +881,7 @@ fn test_deposit_fee_enabled() {
 
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -931,6 +900,7 @@ fn test_deposit_fee_enabled() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -1015,8 +985,7 @@ fn test_deposit_payment_doesnt_cover_fee() {
 
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
 
     let fee = FeeStruct {
         base_token: TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -1032,6 +1001,7 @@ fn test_deposit_payment_doesnt_cover_fee() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         TokenIdentifier::from(FIRST_TEST_TOKEN),
@@ -1095,8 +1065,7 @@ fn test_deposit_refund() {
 
     state
         .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
-    state.complete_setup_phase(None, Some("unpauseContract"));
+        .deploy_mvx_esdt_safe(OptionalValue::Some(config));
 
     let per_transfer = BigUint::from(100u64);
     let per_gas = BigUint::from(1u64);
@@ -1115,6 +1084,7 @@ fn test_deposit_refund() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -1184,11 +1154,14 @@ fn test_deposit_success_burn_mechanism() {
     let mut state = MvxEsdtSafeTestState::new();
 
     state.deploy_contract_with_roles();
-    state.complete_setup_phase(None, Some("unpauseContract"));
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
     state
         .common_setup
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism(TRUSTED_TOKEN_IDS[0], None);
 
@@ -1249,10 +1222,7 @@ fn test_deposit_success_burn_mechanism() {
 #[test]
 fn test_register_token_fungible_token_with_prefix() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = SOV_TOKEN;
     let token_type = EsdtTokenType::Fungible;
@@ -1285,10 +1255,7 @@ fn test_register_token_fungible_token_with_prefix() {
 #[test]
 fn test_register_token_fungible_token_no_prefix() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let sov_token_id = FIRST_TEST_TOKEN;
     let token_type = EsdtTokenType::Fungible;
@@ -1327,10 +1294,7 @@ fn test_register_token_fungible_token_no_prefix() {
 #[test]
 fn test_register_native_token_already_registered() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state
         .common_setup
@@ -1368,10 +1332,7 @@ fn test_register_native_token_already_registered() {
 #[test]
 fn test_register_native_token() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let token_display_name = "TokenOne";
     let egld_payment = BigUint::from(DEFAULT_ISSUE_COST);
@@ -1397,10 +1358,7 @@ fn test_register_native_token() {
 #[test]
 fn test_execute_operation_no_esdt_safe_registered() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, config);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state.complete_setup_phase(None, Some("unpauseContract"));
 
     let payment = OperationEsdtPayment::new(
@@ -1447,10 +1405,7 @@ fn test_execute_operation_no_esdt_safe_registered() {
 #[test]
 fn test_execute_operation_success() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = OptionalValue::Some(EsdtSafeConfig::default_config());
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, config);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.complete_setup_phase(None, Some("unpauseContract"));
 
@@ -1531,10 +1486,7 @@ fn test_execute_operation_success() {
 #[test]
 fn test_execute_operation_with_native_token_success() {
     let mut state = MvxEsdtSafeTestState::new();
-    let config = EsdtSafeConfig::default_config();
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::Some(config));
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     let token_display_name = "TokenOne";
     let egld_payment = BigUint::from(DEFAULT_ISSUE_COST);
@@ -1716,7 +1668,6 @@ fn test_execute_operation_burn_mechanism_without_deposit_cannot_subtract() {
 fn test_execute_operation_success_burn_mechanism() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
-    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let token_data = EsdtTokenData {
         amount: BigUint::from(100u64),
@@ -1757,6 +1708,7 @@ fn test_execute_operation_success_burn_mechanism() {
     state
         .common_setup
         .set_esdt_safe_address_in_header_verifier(ESDT_SAFE_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let operations_hashes = MultiValueEncoded::from(ManagedVec::from(vec![operation_hash.clone()]));
 
@@ -1835,17 +1787,16 @@ fn test_execute_operation_success_burn_mechanism() {
 #[test]
 fn test_deposit_execute_switch_mechanism() {
     let mut state = MvxEsdtSafeTestState::new();
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
     state.deploy_contract_with_roles();
-    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let trusted_token_id = TRUSTED_TOKEN_IDS[0];
 
     state
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
-    state
-        .common_setup
-        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
     state
         .common_setup
         .complete_header_verifier_setup_phase(None);
@@ -1857,6 +1808,7 @@ fn test_deposit_execute_switch_mechanism() {
     state
         .common_setup
         .set_esdt_safe_address_in_header_verifier(ESDT_SAFE_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     let deposited_trusted_token_payment_amount = 1000u64;
     let deposit_trusted_token_payment_token_data = EsdtTokenData {
@@ -2073,10 +2025,9 @@ fn test_deposit_execute_switch_mechanism() {
 #[test]
 fn test_execute_operation_no_payments() {
     let mut state = MvxEsdtSafeTestState::new();
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state
+        .common_setup
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()));
 
     let token_display_name = "TokenOne";
     let egld_payment = BigUint::from(DEFAULT_ISSUE_COST);
@@ -2163,10 +2114,9 @@ fn test_execute_operation_no_payments() {
 #[test]
 fn test_execute_operation_no_payments_failed_event() {
     let mut state = MvxEsdtSafeTestState::new();
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state
+        .common_setup
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()));
 
     state
         .common_setup
@@ -2253,10 +2203,13 @@ fn test_execute_operation_no_payments_failed_event() {
 #[test]
 fn test_set_token_burn_mechanism_no_roles() {
     let mut state = MvxEsdtSafeTestState::new();
-    state.common_setup.deploy_mvx_esdt_safe(
-        HEADER_VERIFIER_ADDRESS,
-        OptionalValue::Some(EsdtSafeConfig::default_config()),
-    );
+    state
+        .common_setup
+        .deploy_mvx_esdt_safe(OptionalValue::Some(EsdtSafeConfig::default_config()));
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism("WEGLD", Some(MINT_AND_BURN_ROLES_NOT_FOUND));
 }
@@ -2273,6 +2226,10 @@ fn test_set_token_burn_mechanism_no_roles() {
 fn test_set_token_burn_mechanism_token_not_trusted() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism(FIRST_TEST_TOKEN.as_str(), Some(TOKEN_ID_IS_NOT_TRUSTED));
 }
@@ -2289,6 +2246,10 @@ fn test_set_token_burn_mechanism_token_not_trusted() {
 fn test_set_token_burn_mechanism() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism(TRUSTED_TOKEN_IDS[0], None);
 
@@ -2323,6 +2284,10 @@ fn test_set_token_burn_mechanism() {
 fn test_set_token_lock_mechanism() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism(TRUSTED_TOKEN_IDS[0], None);
     state.set_token_lock_mechanism(TRUSTED_TOKEN_IDS[0], None);
@@ -2356,6 +2321,10 @@ fn test_set_token_lock_mechanism() {
 fn test_set_token_lock_mechanism_token_from_sovereign() {
     let mut state = MvxEsdtSafeTestState::new();
     state.deploy_contract_with_roles();
+    state
+        .common_setup
+        .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
+    state.complete_setup_phase(None, Some("unpauseContract"));
 
     state.set_token_burn_mechanism(TRUSTED_TOKEN_IDS[0], None);
 

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -324,5 +325,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -324,5 +325,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -324,5 +325,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
@@ -46,9 +46,6 @@ fn test_deposit_no_fee_no_transfer_data() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         FIRST_TEST_TOKEN.into(),
@@ -132,9 +129,6 @@ fn test_deposit_with_fee_no_transfer_data() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -220,9 +214,6 @@ fn test_deposit_no_fee_with_transfer_data() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         FIRST_TEST_TOKEN.into(),
@@ -320,9 +311,6 @@ fn test_deposit_with_fee_with_transfer_data() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -417,9 +405,6 @@ fn test_deposit_no_transfer_data_no_payments() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     state.deposit(
         USER_ADDRESS.to_managed_address(),
@@ -448,9 +433,6 @@ fn test_deposit_sc_call_only() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
-    state
-        .common_setup
-        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let gas_limit = 2;
     let function = ManagedBuffer::<StaticApi>::from("hello");

--- a/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
+++ b/sov-esdt-safe/tests/sov_esdt_safe_blackbox_tests.rs
@@ -46,6 +46,9 @@ fn test_deposit_no_fee_no_transfer_data() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         FIRST_TEST_TOKEN.into(),
@@ -129,6 +132,9 @@ fn test_deposit_with_fee_no_transfer_data() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -214,6 +220,9 @@ fn test_deposit_no_fee_with_transfer_data() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let esdt_token_payment_one = EsdtTokenPayment::<StaticApi>::new(
         FIRST_TEST_TOKEN.into(),
@@ -311,6 +320,9 @@ fn test_deposit_with_fee_with_transfer_data() {
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let fee_amount = BigUint::from(ONE_HUNDRED_THOUSAND);
 
@@ -405,6 +417,9 @@ fn test_deposit_no_transfer_data_no_payments() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     state.deposit(
         USER_ADDRESS.to_managed_address(),
@@ -433,6 +448,9 @@ fn test_deposit_sc_call_only() {
         .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
     state.common_setup.deploy_testing_sc();
     state.set_fee_market_address(FEE_MARKET_ADDRESS);
+    state
+        .common_setup
+        .change_ownership_to_header_verifier(ESDT_SAFE_ADDRESS);
 
     let gas_limit = 2;
     let function = ManagedBuffer::<StaticApi>::from("hello");

--- a/sov-esdt-safe/wasm-sov-esdt-safe-full/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe-full/Cargo.lock
@@ -297,5 +297,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sov-esdt-safe/wasm-sov-esdt-safe-view/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe-view/Cargo.lock
@@ -297,5 +297,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sov-esdt-safe/wasm-sov-esdt-safe/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe/Cargo.lock
@@ -297,5 +297,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sovereign-forge/tests/sovereign_forge_blackbox_tests.rs
+++ b/sovereign-forge/tests/sovereign_forge_blackbox_tests.rs
@@ -1,8 +1,7 @@
 use chain_config::validator_rules::ValidatorRulesModule;
 use common_test_setup::constants::{
     CHAIN_CONFIG_ADDRESS, CHAIN_FACTORY_SC_ADDRESS, CHAIN_ID, DEPLOY_COST, ESDT_SAFE_ADDRESS,
-    FIRST_TEST_TOKEN, HEADER_VERIFIER_ADDRESS, ONE_HUNDRED_THOUSAND, OWNER_ADDRESS,
-    SOVEREIGN_FORGE_SC_ADDRESS,
+    FIRST_TEST_TOKEN, ONE_HUNDRED_THOUSAND, OWNER_ADDRESS, SOVEREIGN_FORGE_SC_ADDRESS,
 };
 use cross_chain::storage::CrossChainStorage;
 use error_messages::{
@@ -261,9 +260,7 @@ fn test_update_esdt_safe_config() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -357,9 +354,7 @@ fn test_set_fee() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state.common_setup.deploy_phase_two(None);
     state
         .common_setup
@@ -459,9 +454,7 @@ fn test_remove_fee() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
     state.common_setup.deploy_phase_two(None);
     state
         .common_setup
@@ -563,9 +556,7 @@ fn test_complete_setup_phase() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -967,9 +958,7 @@ fn test_deploy_phase_three() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -1040,9 +1029,7 @@ fn test_deploy_phase_three_without_phase_two() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state
         .common_setup
@@ -1075,9 +1062,7 @@ fn test_deploy_phase_three_already_deployed() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -1135,9 +1120,7 @@ fn test_deploy_phase_four() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -1189,9 +1172,7 @@ fn test_deploy_phase_four_without_previous_phase() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state
@@ -1228,9 +1209,7 @@ fn test_deploy_phase_four_fee_market_already_deployed() {
     state
         .common_setup
         .deploy_header_verifier(CHAIN_CONFIG_ADDRESS);
-    state
-        .common_setup
-        .deploy_mvx_esdt_safe(HEADER_VERIFIER_ADDRESS, OptionalValue::None);
+    state.common_setup.deploy_mvx_esdt_safe(OptionalValue::None);
 
     state.common_setup.deploy_phase_two(None);
     state

--- a/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -366,5 +367,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sovereign-forge/wasm-sovereign-forge/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -366,5 +367,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
+++ b/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -366,5 +367,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/token-handler/wasm-token-handler-full/Cargo.lock
+++ b/token-handler/wasm-token-handler-full/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -300,5 +301,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/token-handler/wasm-token-handler-view/Cargo.lock
+++ b/token-handler/wasm-token-handler-view/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -300,5 +301,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]

--- a/token-handler/wasm-token-handler/Cargo.lock
+++ b/token-handler/wasm-token-handler/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "proxies",
  "setup-phase",
  "structs",
+ "utils",
 ]
 
 [[package]]
@@ -300,5 +301,6 @@ version = "0.1.0"
 dependencies = [
  "error-messages",
  "multiversx-sc",
+ "proxies",
  "structs",
 ]


### PR DESCRIPTION
Added `lock_operation_hash` and `remove_execute_hash` to utils module. 

Since the header-verifier SC will be the owner of most contracts, it's address can be returned from the `blockain().get_owner_address()`. With this the `header_verifier_address` storage was removed from all contracts.