### PR TITLE
Fee-Market hash locking logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ version = "0.1.0"
 dependencies = [
  "common-test-setup",
  "error-messages",
+ "events",
  "multiversx-sc",
  "multiversx-sc-scenario",
  "num-bigint",

--- a/chain-factory/src/update_configs.rs
+++ b/chain-factory/src/update_configs.rs
@@ -46,7 +46,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(fee_market_address)
             .typed(FeeMarketProxy)
-            .set_fee(new_fee)
+            .set_fee_during_setup_phase(new_fee)
             .sync_call();
     }
 
@@ -56,7 +56,7 @@ pub trait UpdateConfigsModule: only_admin::OnlyAdminModule {
         self.tx()
             .to(fee_market_address)
             .typed(FeeMarketProxy)
-            .remove_fee(token_id)
+            .remove_fee_during_setup_phase(token_id)
             .sync_call();
     }
 }

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -455,7 +455,7 @@ impl BaseSetup {
 
     pub fn set_fee_during_setup_phase(
         &mut self,
-        fee_struct: Option<FeeStruct<StaticApi>>,
+        fee_struct: FeeStruct<StaticApi>,
         error_message: Option<&str>,
     ) {
         let response = self
@@ -464,7 +464,7 @@ impl BaseSetup {
             .from(OWNER_ADDRESS)
             .to(FEE_MARKET_ADDRESS)
             .typed(FeeMarketProxy)
-            .set_fee_during_setup_phase(fee_struct.unwrap())
+            .set_fee_during_setup_phase(fee_struct)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -195,6 +195,22 @@ impl BaseSetup {
         self.assert_expected_error_message(response, expected_error_message);
     }
 
+    pub fn complete_fee_market_setup_phase(&mut self, expected_error_message: Option<&str>) {
+        let response = self
+            .world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(FEE_MARKET_ADDRESS)
+            .typed(FeeMarketProxy)
+            .complete_setup_phase()
+            .returns(ReturnsHandledOrError::new())
+            .run();
+
+        self.change_ownership_to_header_verifier(FEE_MARKET_ADDRESS);
+
+        self.assert_expected_error_message(response, expected_error_message);
+    }
+
     pub fn complete_sovereign_forge_setup_phase(&mut self, expected_error_message: Option<&str>) {
         let response = self
             .world

--- a/common/common-test-setup/src/lib.rs
+++ b/common/common-test-setup/src/lib.rs
@@ -437,7 +437,7 @@ impl BaseSetup {
             .run();
     }
 
-    pub fn set_fee(
+    pub fn set_fee_during_setup_phase(
         &mut self,
         fee_struct: Option<FeeStruct<StaticApi>>,
         error_message: Option<&str>,
@@ -448,7 +448,26 @@ impl BaseSetup {
             .from(OWNER_ADDRESS)
             .to(FEE_MARKET_ADDRESS)
             .typed(FeeMarketProxy)
-            .set_fee(fee_struct.unwrap())
+            .set_fee_during_setup_phase(fee_struct.unwrap())
+            .returns(ReturnsHandledOrError::new())
+            .run();
+
+        self.assert_expected_error_message(response, error_message);
+    }
+
+    pub fn set_fee(
+        &mut self,
+        hash_of_hashes: &ManagedBuffer<StaticApi>,
+        fee_struct: Option<FeeStruct<StaticApi>>,
+        error_message: Option<&str>,
+    ) {
+        let response = self
+            .world
+            .tx()
+            .from(OWNER_ADDRESS)
+            .to(FEE_MARKET_ADDRESS)
+            .typed(FeeMarketProxy)
+            .set_fee(hash_of_hashes, fee_struct.unwrap())
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -92,3 +92,4 @@ pub const TOKEN_ID_NO_PREFIX: &str = "Token Id does not have prefix";
 pub const TOKEN_IS_FROM_SOVEREIGN: &str = "Token is from a Sovereign Chain, it cannot be locked";
 pub const TOKEN_NOT_ACCEPTED_AS_FEE: &str = "Token not accepted as fee";
 pub const TOO_MANY_TOKENS: &str = "Too many tokens";
+pub const ERROR_AT_ENCODING: &str = "Error at encoding";

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -9,6 +9,7 @@ pub const CALLER_DID_NOT_DEPLOY_ANY_SOV_CHAIN: &str =
     "The current caller has not deployed any Sovereign Chain";
 pub const CALLER_NOT_FROM_CURRENT_SOVEREIGN: &str =
     "Caller is not from the current Sovereign-Chain";
+pub const CALLER_NOT_OWNER: &str = "Endpoint can only be called by owner";
 pub const CALLER_IS_NOT_WHITELISTED: &str = "Caller is not whitelisted";
 pub const CANNOT_REGISTER_TOKEN: &str = "Cannot register token";
 pub const COULD_NOT_RETRIEVE_SOVEREIGN_CONFIG: &str = "Error at retrieving Sovereign Config";

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -225,20 +225,14 @@ where
     }
 
     pub fn subtract_fee<
-        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
-        Arg1: ProxyArg<usize>,
-        Arg2: ProxyArg<OptionalValue<u64>>,
+        Arg0: ProxyArg<structs::fee::FeeContext<Env::Api>>,
     >(
         self,
-        original_caller: Arg0,
-        total_transfers: Arg1,
-        opt_gas_limit: Arg2,
+        fee_context: Arg0,
     ) -> TxTypedCall<Env, From, To, (), Gas, structs::fee::FinalPayment<Env::Api>> {
         self.wrapped_tx
             .raw_call("subtractFee")
-            .argument(&original_caller)
-            .argument(&total_transfers)
-            .argument(&opt_gas_limit)
+            .argument(&fee_context)
             .original_result()
     }
 

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -118,7 +118,23 @@ where
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
+            .raw_call("removeFeeDuringSetupPhase")
+            .argument(&base_token)
+            .original_result()
+    }
+
+    pub fn remove_fee<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<TokenIdentifier<Env::Api>>,
+    >(
+        self,
+        hash_of_hashes: Arg0,
+        base_token: Arg1,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
             .raw_call("removeFee")
+            .argument(&hash_of_hashes)
             .argument(&base_token)
             .original_result()
     }
@@ -131,7 +147,23 @@ where
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
+            .raw_call("setFeeDuringSetupPhase")
+            .argument(&fee_struct)
+            .original_result()
+    }
+
+    pub fn set_fee<
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
+    >(
+        self,
+        hash_of_hashes: Arg0,
+        fee_struct: Arg1,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
             .raw_call("setFee")
+            .argument(&hash_of_hashes)
             .argument(&fee_struct)
             .original_result()
     }

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -110,35 +110,29 @@ where
             .original_result()
     }
 
-    pub fn set_fee<
-        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
-        Arg1: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
+    pub fn remove_fee_during_setup_phase<
+        Arg0: ProxyArg<TokenIdentifier<Env::Api>>,
     >(
         self,
-        hash_of_hashes: Arg0,
-        fee_struct: Arg1,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
-        self.wrapped_tx
-            .payment(NotPayable)
-            .raw_call("setFee")
-            .argument(&hash_of_hashes)
-            .argument(&fee_struct)
-            .original_result()
-    }
-
-    pub fn remove_fee<
-        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
-        Arg1: ProxyArg<TokenIdentifier<Env::Api>>,
-    >(
-        self,
-        hash_of_hashes: Arg0,
-        base_token: Arg1,
+        base_token: Arg0,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("removeFee")
-            .argument(&hash_of_hashes)
             .argument(&base_token)
+            .original_result()
+    }
+
+    pub fn set_fee_during_setup_phase<
+        Arg0: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
+    >(
+        self,
+        fee_struct: Arg0,
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+        self.wrapped_tx
+            .payment(NotPayable)
+            .raw_call("setFee")
+            .argument(&fee_struct)
             .original_result()
     }
 

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -111,27 +111,33 @@ where
     }
 
     pub fn set_fee<
-        Arg0: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<structs::fee::FeeStruct<Env::Api>>,
     >(
         self,
-        fee_struct: Arg0,
+        hash_of_hashes: Arg0,
+        fee_struct: Arg1,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("setFee")
+            .argument(&hash_of_hashes)
             .argument(&fee_struct)
             .original_result()
     }
 
     pub fn remove_fee<
-        Arg0: ProxyArg<TokenIdentifier<Env::Api>>,
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<TokenIdentifier<Env::Api>>,
     >(
         self,
-        base_token: Arg0,
+        hash_of_hashes: Arg0,
+        base_token: Arg1,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("removeFee")
+            .argument(&hash_of_hashes)
             .argument(&base_token)
             .original_result()
     }
@@ -177,14 +183,17 @@ where
 
     /// Percentages have to be between 0 and 10_000, and must all add up to 100% (i.e. 10_000) 
     pub fn distribute_fees<
-        Arg0: ProxyArg<MultiValueEncoded<Env::Api, MultiValue2<ManagedAddress<Env::Api>, usize>>>,
+        Arg0: ProxyArg<ManagedBuffer<Env::Api>>,
+        Arg1: ProxyArg<MultiValueEncoded<Env::Api, MultiValue2<ManagedAddress<Env::Api>, usize>>>,
     >(
         self,
-        address_percentage_pairs: Arg0,
+        hash_of_hashes: Arg0,
+        address_percentage_pairs: Arg1,
     ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("distributeFees")
+            .argument(&hash_of_hashes)
             .argument(&address_percentage_pairs)
             .original_result()
     }

--- a/common/proxies/src/fee_market_proxy.rs
+++ b/common/proxies/src/fee_market_proxy.rs
@@ -225,14 +225,20 @@ where
     }
 
     pub fn subtract_fee<
-        Arg0: ProxyArg<structs::fee::FeeContext<Env::Api>>,
+        Arg0: ProxyArg<ManagedAddress<Env::Api>>,
+        Arg1: ProxyArg<usize>,
+        Arg2: ProxyArg<OptionalValue<u64>>,
     >(
         self,
-        fee_context: Arg0,
+        original_caller: Arg0,
+        total_transfers: Arg1,
+        opt_gas_limit: Arg2,
     ) -> TxTypedCall<Env, From, To, (), Gas, structs::fee::FinalPayment<Env::Api>> {
         self.wrapped_tx
             .raw_call("subtractFee")
-            .argument(&fee_context)
+            .argument(&original_caller)
+            .argument(&total_transfers)
+            .argument(&opt_gas_limit)
             .original_result()
     }
 

--- a/common/structs/src/fee.rs
+++ b/common/structs/src/fee.rs
@@ -6,7 +6,7 @@ multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
 
 #[type_abi]
-#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, Clone)]
+#[derive(TopEncode, TopDecode, NestedEncode, NestedDecode, Clone, PartialEq)]
 pub enum FeeType<M: ManagedTypeApi> {
     None,
     Fixed {

--- a/common/structs/src/fee.rs
+++ b/common/structs/src/fee.rs
@@ -47,16 +47,6 @@ pub struct AddressPercentagePair<M: ManagedTypeApi> {
 
 impl<A: CryptoApi> GenerateHash<A> for AddressPercentagePair<A> {}
 
-#[type_abi]
-#[derive(TopEncode, TopDecode)]
-pub struct FeeContext<M: ManagedTypeApi> {
-    pub original_caller: ManagedAddress<M>,
-    pub total_transfers: usize,
-    pub opt_gas_limit: Option<GasLimit>,
-}
-
-impl<A: CryptoApi> GenerateHash<A> for FeeContext<A> {}
-
 pub struct SubtractPaymentArguments<M: ManagedTypeApi> {
     pub fee_token: TokenIdentifier<M>,
     pub per_transfer: BigUint<M>,

--- a/common/structs/src/fee.rs
+++ b/common/structs/src/fee.rs
@@ -1,4 +1,6 @@
-use crate::aliases::GasLimit;
+use multiversx_sc::api::CryptoApi;
+
+use crate::{aliases::GasLimit, generate_hash::GenerateHash};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
@@ -26,6 +28,9 @@ pub struct FeeStruct<M: ManagedTypeApi> {
     pub fee_type: FeeType<M>,
 }
 
+impl<A: CryptoApi> GenerateHash<A> for FeeStruct<A> {}
+impl<A: CryptoApi> GenerateHash<A> for TokenIdentifier<A> {}
+
 #[type_abi]
 #[derive(TopEncode, TopDecode)]
 pub struct FinalPayment<M: ManagedTypeApi> {
@@ -33,11 +38,14 @@ pub struct FinalPayment<M: ManagedTypeApi> {
     pub remaining_tokens: EsdtTokenPayment<M>,
 }
 
+#[type_abi]
 #[derive(TopEncode, TopDecode, ManagedVecItem)]
 pub struct AddressPercentagePair<M: ManagedTypeApi> {
     pub address: ManagedAddress<M>,
     pub percentage: usize,
 }
+
+impl<A: CryptoApi> GenerateHash<A> for AddressPercentagePair<A> {}
 
 pub struct SubtractPaymentArguments<M: ManagedTypeApi> {
     pub fee_token: TokenIdentifier<M>,

--- a/common/structs/src/fee.rs
+++ b/common/structs/src/fee.rs
@@ -47,6 +47,16 @@ pub struct AddressPercentagePair<M: ManagedTypeApi> {
 
 impl<A: CryptoApi> GenerateHash<A> for AddressPercentagePair<A> {}
 
+#[type_abi]
+#[derive(TopEncode, TopDecode)]
+pub struct FeeContext<M: ManagedTypeApi> {
+    pub original_caller: ManagedAddress<M>,
+    pub total_transfers: usize,
+    pub opt_gas_limit: Option<GasLimit>,
+}
+
+impl<A: CryptoApi> GenerateHash<A> for FeeContext<A> {}
+
 pub struct SubtractPaymentArguments<M: ManagedTypeApi> {
     pub fee_token: TokenIdentifier<M>,
     pub per_transfer: BigUint<M>,

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -36,8 +36,8 @@ pub trait UtilsModule {
         );
     }
 
-    fn require_valid_token_id(&self, token_id: &TokenIdentifier) {
-        require!(token_id.is_valid_esdt_identifier(), INVALID_TOKEN_ID);
+    fn is_valid_token_id(&self, token_id: &TokenIdentifier) -> bool {
+        token_id.is_valid_esdt_identifier()
     }
 
     fn remove_items<

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use error_messages::{
-    ERR_EMPTY_PAYMENTS, INVALID_SC_ADDRESS, INVALID_TOKEN_ID, ITEM_NOT_IN_LIST, TOKEN_ID_NO_PREFIX,
+    ERR_EMPTY_PAYMENTS, INVALID_SC_ADDRESS, ITEM_NOT_IN_LIST, TOKEN_ID_NO_PREFIX,
 };
 use proxies::header_verifier_proxy::HeaderverifierProxy;
 use structs::aliases::PaymentsVec;

--- a/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_tests.rs
+++ b/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_tests.rs
@@ -353,7 +353,9 @@ fn test_deposit_no_transfer_data() {
 
     state.setup_contracts(false, Some(&fee_struct), None);
     state.add_token_to_whitelist(tokens_whitelist);
-    state.common_setup.set_fee(Some(fee_struct), None);
+    state
+        .common_setup
+        .set_fee_during_setup_phase(Some(fee_struct), None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,
@@ -519,7 +521,9 @@ fn test_deposit_with_transfer_data_enough_for_fee() {
 
     state.setup_contracts(false, Some(&fee_struct), None);
     // state.set_max_user_tx_gas_limit(gas_limit);
-    state.common_setup.set_fee(Some(fee_struct), None);
+    state
+        .common_setup
+        .set_fee_during_setup_phase(Some(fee_struct), None);
     state.deposit(OWNER_ADDRESS, USER_ADDRESS, payments, transfer_data, None);
 
     let fee = fee_amount_per_transfer * BigUint::from(2u32)
@@ -576,7 +580,9 @@ fn test_deposit_with_transfer_data_not_enough_for_fee() {
 
     state.setup_contracts(false, Some(&fee_struct), None);
     // state.set_max_user_tx_gas_limit(gas_limit);
-    state.common_setup.set_fee(Some(fee_struct), None);
+    state
+        .common_setup
+        .set_fee_during_setup_phase(Some(fee_struct), None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,
@@ -674,7 +680,9 @@ fn test_deposit_refund_non_whitelisted_tokens_fee_enabled() {
 
     state.setup_contracts(false, Some(&fee_struct), None);
     state.add_token_to_whitelist(token_whitelist);
-    state.common_setup.set_fee(Some(fee_struct), None);
+    state
+        .common_setup
+        .set_fee_during_setup_phase(Some(fee_struct), None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,

--- a/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_tests.rs
+++ b/enshrine-esdt-safe/tests/enshrine_esdt_safe_blackbox_tests.rs
@@ -355,7 +355,7 @@ fn test_deposit_no_transfer_data() {
     state.add_token_to_whitelist(tokens_whitelist);
     state
         .common_setup
-        .set_fee_during_setup_phase(Some(fee_struct), None);
+        .set_fee_during_setup_phase(fee_struct, None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,
@@ -523,7 +523,7 @@ fn test_deposit_with_transfer_data_enough_for_fee() {
     // state.set_max_user_tx_gas_limit(gas_limit);
     state
         .common_setup
-        .set_fee_during_setup_phase(Some(fee_struct), None);
+        .set_fee_during_setup_phase(fee_struct, None);
     state.deposit(OWNER_ADDRESS, USER_ADDRESS, payments, transfer_data, None);
 
     let fee = fee_amount_per_transfer * BigUint::from(2u32)
@@ -582,7 +582,7 @@ fn test_deposit_with_transfer_data_not_enough_for_fee() {
     // state.set_max_user_tx_gas_limit(gas_limit);
     state
         .common_setup
-        .set_fee_during_setup_phase(Some(fee_struct), None);
+        .set_fee_during_setup_phase(fee_struct, None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,
@@ -682,7 +682,7 @@ fn test_deposit_refund_non_whitelisted_tokens_fee_enabled() {
     state.add_token_to_whitelist(token_whitelist);
     state
         .common_setup
-        .set_fee_during_setup_phase(Some(fee_struct), None);
+        .set_fee_during_setup_phase(fee_struct, None);
     state.deposit(
         OWNER_ADDRESS,
         USER_ADDRESS,

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-full/Cargo.lock
@@ -111,6 +111,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe-view/Cargo.lock
@@ -111,6 +111,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
+++ b/enshrine-esdt-safe/wasm-enshrine-esdt-safe/Cargo.lock
@@ -111,6 +111,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/fee-market/Cargo.toml
+++ b/fee-market/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[dependencies.multiversx-sc]
+version = "=0.58.0"
+
 [dependencies.utils]
 path = "../common/utils"
 
@@ -19,9 +22,6 @@ path = "../common/proxies"
 
 [dependencies.structs]
 path = "../common/structs"
-
-[dependencies.multiversx-sc]
-version = "=0.58.0"
 
 [dependencies.error-messages]
 path = "../common/error-messages"

--- a/fee-market/Cargo.toml
+++ b/fee-market/Cargo.toml
@@ -26,6 +26,9 @@ path = "../common/structs"
 [dependencies.error-messages]
 path = "../common/error-messages"
 
+[dependencies.events]
+path = "../common/events"
+
 [dev-dependencies]
 num-bigint = "0.4.2"
 

--- a/fee-market/src/fee_type.rs
+++ b/fee-market/src/fee_type.rs
@@ -12,7 +12,7 @@ pub trait FeeTypeModule:
     utils::UtilsModule + setup_phase::SetupPhaseModule + events::EventsModule
 {
     #[only_owner]
-    #[endpoint(removeFee)]
+    #[endpoint(removeFeeDuringSetupPhase)]
     fn remove_fee_during_setup_phase(&self, base_token: TokenIdentifier) {
         self.token_fee(&base_token).clear();
         self.fee_enabled().set(false);
@@ -33,7 +33,7 @@ pub trait FeeTypeModule:
     }
 
     #[only_owner]
-    #[endpoint(setFee)]
+    #[endpoint(setFeeDuringSetupPhase)]
     fn set_fee_during_setup_phase(&self, fee_struct: FeeStruct<Self::Api>) {
         if let Some(set_fee_error_msg) = self.set_fee_in_storage(&fee_struct) {
             sc_panic!(set_fee_error_msg);

--- a/fee-market/src/fee_type.rs
+++ b/fee-market/src/fee_type.rs
@@ -30,6 +30,7 @@ pub trait FeeTypeModule:
         self.fee_enabled().set(false);
 
         self.remove_executed_hash(&hash_of_hashes, &token_id_hash);
+        self.execute_bridge_operation_event(&hash_of_hashes, &token_id_hash);
     }
 
     #[only_owner]

--- a/fee-market/src/lib.rs
+++ b/fee-market/src/lib.rs
@@ -25,7 +25,7 @@ pub trait FeeMarket:
         self.esdt_safe_address().set(esdt_safe_address);
 
         match fee {
-            Some(fee_struct) => self.set_fee(fee_struct),
+            Some(fee_struct) => self.set_fee_in_storage(&fee_struct),
             _ => self.fee_enabled().set(false),
         }
     }

--- a/fee-market/src/lib.rs
+++ b/fee-market/src/lib.rs
@@ -18,6 +18,7 @@ pub trait FeeMarket:
     + price_aggregator::PriceAggregatorModule
     + utils::UtilsModule
     + setup_phase::SetupPhaseModule
+    + events::EventsModule
 {
     #[init]
     fn init(&self, esdt_safe_address: ManagedAddress, fee: Option<FeeStruct<Self::Api>>) {
@@ -25,7 +26,9 @@ pub trait FeeMarket:
         self.esdt_safe_address().set(esdt_safe_address);
 
         match fee {
-            Some(fee_struct) => self.set_fee_in_storage(&fee_struct),
+            Some(fee_struct) => {
+                let _ = self.set_fee_in_storage(&fee_struct);
+            }
             _ => self.fee_enabled().set(false),
         }
     }

--- a/fee-market/src/subtract_fee.rs
+++ b/fee-market/src/subtract_fee.rs
@@ -68,7 +68,7 @@ pub trait SubtractFeeModule:
 
         self.lock_operation_hash(&hash_of_hashes, &pairs_hash);
 
-        if percentage_sum == TOTAL_PERCENTAGE as u64 {
+        if !percentage_sum == TOTAL_PERCENTAGE as u64 {
             self.failed_bridge_operation_event(
                 &hash_of_hashes,
                 &pairs_hash,

--- a/fee-market/src/subtract_fee.rs
+++ b/fee-market/src/subtract_fee.rs
@@ -1,6 +1,6 @@
 use error_messages::{
-    ERROR_AT_ENCODING, INVALID_PERCENTAGE_SUM, INVALID_TOKEN_PROVIDED_FOR_FEE,
-    PAYMENT_DOES_NOT_COVER_FEE, TOKEN_NOT_ACCEPTED_AS_FEE,
+    INVALID_PERCENTAGE_SUM, INVALID_TOKEN_PROVIDED_FOR_FEE, PAYMENT_DOES_NOT_COVER_FEE,
+    TOKEN_NOT_ACCEPTED_AS_FEE,
 };
 use structs::{
     aliases::GasLimit,
@@ -68,7 +68,7 @@ pub trait SubtractFeeModule:
 
         self.lock_operation_hash(&hash_of_hashes, pairs_hash_byte_array.as_managed_buffer());
 
-        if !percentage_sum == TOTAL_PERCENTAGE as u64 {
+        if percentage_sum != TOTAL_PERCENTAGE as u64 {
             self.failed_bridge_operation_event(
                 &hash_of_hashes,
                 pairs_hash_byte_array.as_managed_buffer(),

--- a/fee-market/src/subtract_fee.rs
+++ b/fee-market/src/subtract_fee.rs
@@ -4,7 +4,7 @@ use error_messages::{
 };
 use structs::{
     aliases::GasLimit,
-    fee::{AddressPercentagePair, FeeContext, FeeType, FinalPayment, SubtractPaymentArguments},
+    fee::{AddressPercentagePair, FeeType, FinalPayment, SubtractPaymentArguments},
     generate_hash::GenerateHash,
 };
 

--- a/fee-market/src/subtract_fee.rs
+++ b/fee-market/src/subtract_fee.rs
@@ -4,7 +4,7 @@ use error_messages::{
 };
 use structs::{
     aliases::GasLimit,
-    fee::{AddressPercentagePair, FeeType, FinalPayment, SubtractPaymentArguments},
+    fee::{AddressPercentagePair, FeeContext, FeeType, FinalPayment, SubtractPaymentArguments},
     generate_hash::GenerateHash,
 };
 
@@ -115,18 +115,17 @@ pub trait SubtractFeeModule:
 
     #[payable("*")]
     #[endpoint(subtractFee)]
-    fn subtract_fee(
-        &self,
-        original_caller: ManagedAddress,
-        total_transfers: usize,
-        opt_gas_limit: OptionalValue<GasLimit>,
-    ) -> FinalPayment<Self::Api> {
+    fn subtract_fee(&self, fee_context: FeeContext<Self::Api>) -> FinalPayment<Self::Api> {
         self.require_caller_esdt_safe();
 
         let caller = self.blockchain().get_caller();
         let payment = self.call_value().single_esdt().clone();
 
-        if !self.is_fee_enabled() || self.users_whitelist().contains(&original_caller) {
+        if !self.is_fee_enabled()
+            || self
+                .users_whitelist()
+                .contains(&fee_context.original_caller)
+        {
             self.tx().to(&caller).payment(payment.clone()).transfer();
 
             return FinalPayment {
@@ -135,7 +134,11 @@ pub trait SubtractFeeModule:
             };
         }
 
-        let final_payment = self.subtract_fee_by_type(payment, total_transfers, opt_gas_limit);
+        let final_payment = self.subtract_fee_by_type(
+            payment,
+            fee_context.total_transfers,
+            fee_context.opt_gas_limit.into(),
+        );
 
         self.tokens_for_fees()
             .insert(final_payment.fee.token_identifier.clone());
@@ -145,7 +148,7 @@ pub trait SubtractFeeModule:
 
         if final_payment.remaining_tokens.amount > 0 {
             self.tx()
-                .to(&original_caller)
+                .to(&fee_context.original_caller)
                 .payment(&final_payment.remaining_tokens)
                 .transfer();
         }

--- a/fee-market/tests/fee_market_blackbox_setup.rs
+++ b/fee-market/tests/fee_market_blackbox_setup.rs
@@ -68,7 +68,7 @@ impl FeeMarketTestState {
         }
     }
 
-    pub fn substract_fee(&mut self, payment_wanted: &str, expected_error_message: Option<&str>) {
+    pub fn subtract_fee(&mut self, payment_wanted: &str, expected_error_message: Option<&str>) {
         let payment: EsdtTokenPayment<StaticApi> = match payment_wanted {
             "Correct" => EsdtTokenPayment::new(
                 FIRST_TEST_TOKEN.to_token_identifier(),

--- a/fee-market/tests/fee_market_blackbox_setup.rs
+++ b/fee-market/tests/fee_market_blackbox_setup.rs
@@ -110,18 +110,18 @@ impl FeeMarketTestState {
             .assert_expected_error_message(response, expected_error_message);
     }
 
-    pub fn remove_fee(&mut self) {
+    pub fn remove_fee_during_setup_phase(&mut self) {
         self.common_setup
             .world
             .tx()
             .from(OWNER_ADDRESS)
             .to(FEE_MARKET_ADDRESS)
             .typed(FeeMarketProxy)
-            .remove_fee(FIRST_TEST_TOKEN.to_token_identifier())
+            .remove_fee_during_setup_phase(FIRST_TEST_TOKEN.to_token_identifier())
             .run();
     }
 
-    pub fn set_fee(
+    pub fn set_fee_during_setup_phase(
         &mut self,
         token_id: TestTokenIdentifier,
         fee_type: &str,
@@ -180,7 +180,7 @@ impl FeeMarketTestState {
             .from(OWNER_ADDRESS)
             .to(FEE_MARKET_ADDRESS)
             .typed(FeeMarketProxy)
-            .set_fee(fee_struct)
+            .set_fee_during_setup_phase(fee_struct)
             .returns(ReturnsHandledOrError::new())
             .run();
 

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -465,7 +465,7 @@ fn test_remove_fee_register_with_one_hash_of_hashes() {
 }
 
 /// ### TEST
-/// F-MARKET_DISTRIBUTE_FEES_ERR
+/// F-MARKET_DISTRIBUTE_FEES_FAIL
 ///
 /// ### ACTION
 /// Call 'distribute_fees()' when setup is not completed
@@ -488,7 +488,7 @@ fn distribute_fees_setup_not_completed() {
 }
 
 /// ### TEST
-/// F-MARKET_DISTRIBUTE_FEES_ERR
+/// F-MARKET_DISTRIBUTE_FEES_FAIL
 ///
 /// ### ACTION
 /// Call 'distribute_fees()' when operation is not registered
@@ -526,7 +526,7 @@ fn distribute_fees_operation_not_registered() {
 }
 
 /// ### TEST
-/// F-MARKET_DISTRIBUTE_FEES_ERR
+/// F-MARKET_DISTRIBUTE_FEES_FAIL
 ///
 /// ### ACTION
 /// Call 'distribute_fees()' with one pair

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -23,15 +23,15 @@ fn test_deploy_fee_market() {
 }
 
 /// ### TEST
-/// F-MARKET_SET_FEE_FAIL
+/// F-MARKET_set_fee_during_setup_phase_FAIL
 ///
 /// ### ACTION
-/// Call 'set_fee()' with wrong parameters
+/// Call 'set_fee_during_setup_phase()' with wrong parameters
 ///
 /// ### EXPECTED
 /// Errors: INVALID_TOKEN_ID, INVALID_FEE_TYPE, INVALID_FEE
 #[test]
-fn test_set_fee_wrong_params() {
+fn test_set_fee_during_setup_phase_wrong_params() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -40,13 +40,13 @@ fn test_set_fee_wrong_params() {
         .common_setup
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
 
-    state.set_fee(WRONG_TOKEN_ID, "Fixed", Some(INVALID_TOKEN_ID));
+    state.set_fee_during_setup_phase(WRONG_TOKEN_ID, "Fixed", Some(INVALID_TOKEN_ID));
 
-    state.set_fee(FIRST_TEST_TOKEN, "None", Some(INVALID_FEE_TYPE));
+    state.set_fee_during_setup_phase(FIRST_TEST_TOKEN, "None", Some(INVALID_FEE_TYPE));
 
-    state.set_fee(SECOND_TEST_TOKEN, "Fixed", Some(INVALID_FEE));
+    state.set_fee_during_setup_phase(SECOND_TEST_TOKEN, "Fixed", Some(INVALID_FEE));
 
-    state.set_fee(FIRST_TEST_TOKEN, "AnyTokenWrong", Some(INVALID_TOKEN_ID));
+    state.set_fee_during_setup_phase(FIRST_TEST_TOKEN, "AnyTokenWrong", Some(INVALID_TOKEN_ID));
 }
 
 /// ### TEST
@@ -67,7 +67,7 @@ fn test_substract_fee_no_fee() {
         .common_setup
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
 
-    state.remove_fee();
+    state.remove_fee_during_setup_phase();
 
     state.substract_fee("Correct", None);
 

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -464,6 +464,14 @@ fn test_remove_fee_register_with_one_hash_of_hashes() {
         });
 }
 
+/// ### TEST
+/// F-MARKET_DISTRIBUTE_FEES_ERR
+///
+/// ### ACTION
+/// Call 'distribute_fees()' when setup is not completed
+///
+/// ### EXPECTED
+/// Error CALLER_NOT_OWNER
 #[test]
 fn distribute_fees_setup_not_completed() {
     let mut state = FeeMarketTestState::new();
@@ -479,6 +487,14 @@ fn distribute_fees_setup_not_completed() {
     state.distribute_fees(&ManagedBuffer::new(), vec![], Some(CALLER_NOT_OWNER), None);
 }
 
+/// ### TEST
+/// F-MARKET_DISTRIBUTE_FEES_ERR
+///
+/// ### ACTION
+/// Call 'distribute_fees()' when operation is not registered
+///
+/// ### EXPECTED
+/// Error CURRENT_OPERATION_NOT_REGISTERED
 #[test]
 fn distribute_fees_operation_not_registered() {
     let mut state = FeeMarketTestState::new();
@@ -509,6 +525,14 @@ fn distribute_fees_operation_not_registered() {
     );
 }
 
+/// ### TEST
+/// F-MARKET_DISTRIBUTE_FEES_ERR
+///
+/// ### ACTION
+/// Call 'distribute_fees()' with one pair
+///
+/// ### EXPECTED
+/// OWNER balance is unchanged, `failedBridgeOp` event emitted
 #[test]
 fn distribute_fees_percentage_under_limit() {
     let mut state = FeeMarketTestState::new();
@@ -560,6 +584,14 @@ fn distribute_fees_percentage_under_limit() {
     );
 }
 
+/// ### TEST
+/// F-MARKET_DISTRIBUTE_FEES_OK
+///
+/// ### ACTION
+/// Call 'distribute_fees()' with one pair
+///
+/// ### EXPECTED
+/// OWNER balance is changed, `executedBridgeOp` event emitted
 #[test]
 fn distribute_fees() {
     let mut state = FeeMarketTestState::new();
@@ -568,9 +600,22 @@ fn distribute_fees() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
+    let fee_per_transfer = BigUint::from(100u32);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::Fixed {
+            token: FIRST_TEST_TOKEN.to_token_identifier(),
+            per_transfer: fee_per_transfer.clone(),
+            per_gas: BigUint::default(),
+        },
+    };
+
     state
         .common_setup
-        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+        .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
+
+    state.subtract_fee("Correct", None);
 
     state.common_setup.complete_fee_market_setup_phase(None);
 
@@ -608,6 +653,13 @@ fn distribute_fees() {
         vec![address_pair_tuple],
         None,
         Some("executedBridgeOp"),
+    );
+
+    state.common_setup.check_account_single_esdt(
+        OWNER_ADDRESS.to_address(),
+        FIRST_TEST_TOKEN,
+        0,
+        BigUint::from(OWNER_BALANCE) + fee_per_transfer,
     );
 }
 
@@ -688,7 +740,7 @@ fn test_subtract_fee_whitelisted() {
 }
 
 /// ### TEST
-/// F-MARKET_subtract_FEE_FAIL
+/// F-MARKET_SUBTRACT_FEE_FAIL
 ///
 /// ### ACTION
 /// Call 'subtract_fee()' with an invalid payment token
@@ -723,7 +775,7 @@ fn test_subtract_fee_invalid_payment_token() {
 }
 
 /// ### TEST
-/// F-MARKET_subtract_FEE_FAIL
+/// F-MARKET_SUBTRACT_FEE_FAIL
 ///
 /// ### ACTION
 /// Call 'subtract_fee()' with not enough tokens to cover the fee

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -38,7 +38,7 @@ fn test_deploy_fee_market() {
 }
 
 /// ### TEST
-/// F-MARKET_set_fee_during_setup_phase_FAIL
+/// F-MARKET_SET_FEE_DURING_SETUP_PHASE_FAIL
 ///
 /// ### ACTION
 /// Call 'set_fee_during_setup_phase()' with wrong parameters

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -612,7 +612,7 @@ fn distribute_fees() {
 }
 
 /// ### TEST
-/// F-MARKET_subtract_FEE_OK
+/// F-MARKET_SUBTRACT_FEE_OK
 ///
 /// ### ACTION
 /// Call 'subtract_fee()' with no fee set
@@ -649,7 +649,7 @@ fn test_subtract_fee_no_fee() {
 }
 
 /// ### TEST
-/// F-MARKET_subtract_FEE_OK
+/// F-MARKET_SUBTRACT_FEE_OK
 ///
 /// ### ACTION
 /// Call 'subtract_fee()' with a whitelisted user
@@ -761,7 +761,7 @@ fn test_subtract_fixed_fee_payment_not_covered() {
 }
 
 /// ### TEST
-/// F-MARKET_subtract_FEE_OK
+/// F-MARKET_SUBTRACT_FEE_OK
 ///
 /// ### ACTION
 /// Call 'subtract_fee()' with payment bigger than fee

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -1,13 +1,28 @@
-use common_test_setup::constants::{
-    ESDT_SAFE_ADDRESS, FEE_MARKET_ADDRESS, FIRST_TEST_TOKEN, OWNER_BALANCE, SECOND_TEST_TOKEN,
-    USER_ADDRESS, WRONG_TOKEN_ID,
+use common_test_setup::{
+    constants::{
+        ESDT_SAFE_ADDRESS, FEE_MARKET_ADDRESS, FIRST_TEST_TOKEN, OWNER_ADDRESS, OWNER_BALANCE,
+        SECOND_TEST_TOKEN, USER_ADDRESS, WRONG_TOKEN_ID,
+    },
+    CallerAddress,
 };
 use error_messages::{
-    INVALID_FEE, INVALID_FEE_TYPE, INVALID_TOKEN_ID, PAYMENT_DOES_NOT_COVER_FEE,
-    TOKEN_NOT_ACCEPTED_AS_FEE,
+    CALLER_NOT_OWNER, CURRENT_OPERATION_NOT_REGISTERED, INVALID_FEE, INVALID_FEE_TYPE,
+    INVALID_TOKEN_ID, PAYMENT_DOES_NOT_COVER_FEE, TOKEN_NOT_ACCEPTED_AS_FEE,
 };
+use fee_market::fee_type::FeeTypeModule;
 use fee_market_blackbox_setup::*;
-use multiversx_sc::types::BigUint;
+use multiversx_sc::{
+    imports::{MultiValue2, OptionalValue},
+    types::{BigUint, ManagedBuffer, MultiValueEncoded},
+};
+use multiversx_sc_scenario::{
+    api::StaticApi, multiversx_chain_vm::crypto_functions::sha256, ScenarioTxWhitebox,
+};
+use structs::{
+    fee::{AddressPercentagePair, FeeStruct, FeeType},
+    forge::ScArray,
+    generate_hash::GenerateHash,
+};
 
 mod fee_market_blackbox_setup;
 
@@ -47,6 +62,496 @@ fn test_set_fee_during_setup_phase_wrong_params() {
     state.set_fee_during_setup_phase(SECOND_TEST_TOKEN, "Fixed", Some(INVALID_FEE));
 
     state.set_fee_during_setup_phase(FIRST_TEST_TOKEN, "AnyTokenWrong", Some(INVALID_TOKEN_ID));
+}
+
+/// ### TEST
+/// F-MARKET_SET_FEE_FAIL
+///
+/// ### ACTION
+/// Call `set_fee()` when setup phase is not completed
+///
+/// ### EXPECTED
+/// Error CALLER_NOT_OWNER
+#[test]
+fn test_set_fee_setup_not_completed() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket, ScArray::ChainConfig]);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::None,
+    };
+
+    state.set_fee(&ManagedBuffer::new(), &fee, Some(CALLER_NOT_OWNER), None);
+}
+
+/// ### TEST
+/// F-MARKET_SET_FEE_FAIL
+///
+/// ### ACTION
+/// Call `set_fee()` when operation is not registered
+///
+/// ### EXPECTED
+/// Error CURRENT_OPERATION_NOT_REGISTERED
+#[test]
+fn test_set_fee_invalid_fee_type() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket, ScArray::ChainConfig]);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::None,
+    };
+
+    let fee_hash = fee.generate_hash();
+
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&fee_hash.to_vec()));
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![fee_hash]),
+    );
+
+    state.set_fee(&hash_of_hashes, &fee, Some(INVALID_FEE_TYPE), None);
+}
+
+/// ### TEST
+/// F-MARKET_SET_FEE_FAIL
+///
+/// ### ACTION
+/// Call `set_fee()` when operation is not registered
+///
+/// ### EXPECTED
+/// Error CURRENT_OPERATION_NOT_REGISTERED
+#[test]
+fn test_set_fee_operation_not_registered() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket]);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::None,
+    };
+
+    state.set_fee(
+        &ManagedBuffer::new(),
+        &fee,
+        Some(CURRENT_OPERATION_NOT_REGISTERED),
+        None,
+    );
+}
+
+/// ### TEST
+/// F-MARKET_SET_FEE_OK
+///
+/// ### ACTION
+/// Call `set_fee()`
+///
+/// ### EXPECTED
+/// Fee is set in contract's storage
+#[test]
+fn test_set_fee() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket, ScArray::ChainConfig]);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::Fixed {
+            token: FIRST_TEST_TOKEN.to_token_identifier(),
+            per_transfer: BigUint::default(),
+            per_gas: BigUint::default(),
+        },
+    };
+
+    let fee_hash = fee.generate_hash();
+
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&fee_hash.to_vec()));
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![fee_hash]),
+    );
+
+    state.set_fee(&hash_of_hashes, &fee, None, Some("executedBridgeOp"));
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(FEE_MARKET_ADDRESS)
+        .whitebox(fee_market::contract_obj, |sc| {
+            assert!(!sc
+                .token_fee(&FIRST_TEST_TOKEN.to_token_identifier())
+                .is_empty());
+        });
+}
+
+/// ### TEST
+/// F-MARKET_REMOVE_FEE_FAIL
+///
+/// ### ACTION
+/// Call `remove_fee()` when setup was not completed
+///
+/// ### EXPECTED
+/// Error CALLER_NOT_OWNER
+#[test]
+fn test_remove_fee_setup_phase_not_completed() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket]);
+
+    state.remove_fee(
+        &ManagedBuffer::new(),
+        FIRST_TEST_TOKEN,
+        Some(CALLER_NOT_OWNER),
+        None,
+    );
+}
+
+/// ### TEST
+/// F-MARKET_REMOVE_FEE_OK
+///
+/// ### ACTION
+/// Register `set_fee()` and `remove_fee()` separately and then call `remove_fee`
+///
+/// ### EXPECTED
+/// Fee is removed the contract's storage
+#[test]
+fn test_remove_fee_register_separate_operations() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::ChainConfig, ScArray::FeeMarket]);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::Fixed {
+            token: FIRST_TEST_TOKEN.to_token_identifier(),
+            per_transfer: BigUint::default(),
+            per_gas: BigUint::default(),
+        },
+    };
+
+    let register_fee_hash = fee.generate_hash();
+
+    let register_fee_hash_of_hashes =
+        ManagedBuffer::new_from_bytes(&sha256(&register_fee_hash.to_vec()));
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &register_fee_hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![register_fee_hash]),
+    );
+
+    state.set_fee(
+        &register_fee_hash_of_hashes,
+        &fee,
+        None,
+        Some("executedBridgeOp"),
+    );
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(FEE_MARKET_ADDRESS)
+        .whitebox(fee_market::contract_obj, |sc| {
+            assert!(!sc
+                .token_fee(&FIRST_TEST_TOKEN.to_token_identifier())
+                .is_empty());
+        });
+
+    let remove_fee_hash = sha256(
+        &FIRST_TEST_TOKEN
+            .to_token_identifier::<StaticApi>()
+            .as_managed_buffer()
+            .to_vec(),
+    );
+
+    let remove_fee_hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&remove_fee_hash));
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &remove_fee_hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![ManagedBuffer::new_from_bytes(&remove_fee_hash)]),
+    );
+
+    state.remove_fee(
+        &remove_fee_hash_of_hashes,
+        FIRST_TEST_TOKEN,
+        None,
+        Some("executedBridgeOp"),
+    );
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(FEE_MARKET_ADDRESS)
+        .whitebox(fee_market::contract_obj, |sc| {
+            assert!(sc
+                .token_fee(&FIRST_TEST_TOKEN.to_token_identifier())
+                .is_empty());
+        });
+}
+
+/// ### TEST
+/// F-MARKET_REMOVE_FEE_OK
+///
+/// ### ACTION
+/// Register both `set_fee()` and `remove_fee()` at the same time and then call `remove_fee`
+///
+/// ### EXPECTED
+/// Fee is removed the contract's storage
+#[test]
+fn test_remove_fee_register_with_one_hash_of_hashes() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::ChainConfig, ScArray::FeeMarket]);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    let fee = FeeStruct {
+        base_token: FIRST_TEST_TOKEN.to_token_identifier(),
+        fee_type: FeeType::Fixed {
+            token: FIRST_TEST_TOKEN.to_token_identifier(),
+            per_transfer: BigUint::default(),
+            per_gas: BigUint::default(),
+        },
+    };
+
+    let remove_fee_hash: ManagedBuffer<StaticApi> = ManagedBuffer::new_from_bytes(&sha256(
+        &FIRST_TEST_TOKEN
+            .to_token_identifier::<StaticApi>()
+            .as_managed_buffer()
+            .to_vec(),
+    ));
+    let register_fee_hash = fee.generate_hash();
+    let mut aggregated_hashes = ManagedBuffer::new();
+
+    aggregated_hashes.append(&remove_fee_hash);
+    aggregated_hashes.append(&register_fee_hash);
+
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&aggregated_hashes.to_vec()));
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![remove_fee_hash, register_fee_hash]),
+    );
+
+    state.set_fee(&hash_of_hashes, &fee, None, Some("executedBridgeOp"));
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(FEE_MARKET_ADDRESS)
+        .whitebox(fee_market::contract_obj, |sc| {
+            assert!(!sc
+                .token_fee(&FIRST_TEST_TOKEN.to_token_identifier())
+                .is_empty());
+        });
+
+    state.remove_fee(
+        &hash_of_hashes,
+        FIRST_TEST_TOKEN,
+        None,
+        Some("executedBridgeOp"),
+    );
+
+    state
+        .common_setup
+        .world
+        .query()
+        .to(FEE_MARKET_ADDRESS)
+        .whitebox(fee_market::contract_obj, |sc| {
+            assert!(sc
+                .token_fee(&FIRST_TEST_TOKEN.to_token_identifier())
+                .is_empty());
+        });
+}
+
+#[test]
+fn distribute_fees_setup_not_completed() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::FeeMarket]);
+
+    state.distribute_fees(&ManagedBuffer::new(), vec![], Some(CALLER_NOT_OWNER), None);
+}
+
+#[test]
+fn distribute_fees_operation_not_registered() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::ChainConfig, ScArray::FeeMarket]);
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    state.distribute_fees(
+        &ManagedBuffer::new(),
+        vec![],
+        Some(CURRENT_OPERATION_NOT_REGISTERED),
+        None,
+    );
+}
+
+#[test]
+fn distribute_fees() {
+    let mut state = FeeMarketTestState::new();
+
+    state
+        .common_setup
+        .deploy_chain_config(OptionalValue::None, None);
+
+    state
+        .common_setup
+        .deploy_fee_market(None, ESDT_SAFE_ADDRESS);
+
+    state.common_setup.complete_fee_market_setup_phase(None);
+
+    state
+        .common_setup
+        .deploy_header_verifier(vec![ScArray::ChainConfig, ScArray::FeeMarket]);
+
+    state
+        .common_setup
+        .complete_header_verifier_setup_phase(None);
+
+    let address_pair: AddressPercentagePair<StaticApi> = AddressPercentagePair {
+        address: OWNER_ADDRESS.to_managed_address(),
+        percentage: 10,
+    };
+
+    let address_pair_tuple =
+        MultiValue2::from((address_pair.address.clone(), address_pair.percentage));
+    let address_pair_hash = address_pair.generate_hash();
+    // let mut aggregated_hash: ManagedBuffer<StaticApi> = ManagedBuffer::new();
+    // aggregated_hash.append(&address_pair_hash);
+
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&address_pair_hash.to_vec()));
+
+    state.common_setup.register_operation(
+        CallerAddress::Owner,
+        ManagedBuffer::new(),
+        &hash_of_hashes,
+        MultiValueEncoded::from_iter(vec![address_pair_hash]),
+    );
+
+    state.distribute_fees(&hash_of_hashes, vec![address_pair_tuple], None, None);
 }
 
 /// ### TEST

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -612,15 +612,15 @@ fn distribute_fees() {
 }
 
 /// ### TEST
-/// F-MARKET_SUBSTRACT_FEE_OK
+/// F-MARKET_subtract_FEE_OK
 ///
 /// ### ACTION
-/// Call 'substract_fee()' with no fee set
+/// Call 'subtract_fee()' with no fee set
 ///
 /// ### EXPECTED
 /// User balance is unchanged
 #[test]
-fn test_substract_fee_no_fee() {
+fn test_subtract_fee_no_fee() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -631,7 +631,7 @@ fn test_substract_fee_no_fee() {
 
     state.remove_fee_during_setup_phase();
 
-    state.substract_fee("Correct", None);
+    state.subtract_fee("Correct", None);
 
     state.common_setup.check_account_single_esdt(
         ESDT_SAFE_ADDRESS.to_address(),
@@ -649,15 +649,15 @@ fn test_substract_fee_no_fee() {
 }
 
 /// ### TEST
-/// F-MARKET_SUBSTRACT_FEE_OK
+/// F-MARKET_subtract_FEE_OK
 ///
 /// ### ACTION
-/// Call 'substract_fee()' with a whitelisted user
+/// Call 'subtract_fee()' with a whitelisted user
 ///
 /// ### EXPECTED
 /// User balance is unchanged
 #[test]
-fn test_substract_fee_whitelisted() {
+fn test_subtract_fee_whitelisted() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -670,7 +670,7 @@ fn test_substract_fee_whitelisted() {
 
     state.add_users_to_whitelist(whitelisted_users);
 
-    state.substract_fee("Correct", None);
+    state.subtract_fee("Correct", None);
 
     state.common_setup.check_account_single_esdt(
         ESDT_SAFE_ADDRESS.to_address(),
@@ -688,15 +688,15 @@ fn test_substract_fee_whitelisted() {
 }
 
 /// ### TEST
-/// F-MARKET_SUBSTRACT_FEE_FAIL
+/// F-MARKET_subtract_FEE_FAIL
 ///
 /// ### ACTION
-/// Call 'substract_fee()' with an invalid payment token
+/// Call 'subtract_fee()' with an invalid payment token
 ///
 /// ### EXPECTED
 /// Error TOKEN_NOT_ACCEPTED_AS_FEE
 #[test]
-fn test_substract_fee_invalid_payment_token() {
+fn test_subtract_fee_invalid_payment_token() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -705,7 +705,7 @@ fn test_substract_fee_invalid_payment_token() {
         .common_setup
         .deploy_fee_market(Some(fee), ESDT_SAFE_ADDRESS);
 
-    state.substract_fee("InvalidToken", Some(TOKEN_NOT_ACCEPTED_AS_FEE));
+    state.subtract_fee("InvalidToken", Some(TOKEN_NOT_ACCEPTED_AS_FEE));
 
     state.common_setup.check_account_single_esdt(
         ESDT_SAFE_ADDRESS.to_address(),
@@ -723,15 +723,15 @@ fn test_substract_fee_invalid_payment_token() {
 }
 
 /// ### TEST
-/// F-MARKET_SUBSTRACT_FEE_FAIL
+/// F-MARKET_subtract_FEE_FAIL
 ///
 /// ### ACTION
-/// Call 'substract_fee()' with not enough tokens to cover the fee
+/// Call 'subtract_fee()' with not enough tokens to cover the fee
 ///
 /// ### EXPECTED
 /// Error PAYMENT_DOES_NOT_COVER_FEE
 #[test]
-fn test_substract_fixed_fee_payment_not_covered() {
+fn test_subtract_fixed_fee_payment_not_covered() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -743,7 +743,7 @@ fn test_substract_fixed_fee_payment_not_covered() {
         .common_setup
         .change_ownership_to_header_verifier(FEE_MARKET_ADDRESS);
 
-    state.substract_fee("Less than fee", Some(PAYMENT_DOES_NOT_COVER_FEE));
+    state.subtract_fee("Less than fee", Some(PAYMENT_DOES_NOT_COVER_FEE));
 
     state.common_setup.check_account_single_esdt(
         ESDT_SAFE_ADDRESS.to_address(),
@@ -761,15 +761,15 @@ fn test_substract_fixed_fee_payment_not_covered() {
 }
 
 /// ### TEST
-/// F-MARKET_SUBSTRACT_FEE_OK
+/// F-MARKET_subtract_FEE_OK
 ///
 /// ### ACTION
-/// Call 'substract_fee()' with payment bigger than fee
+/// Call 'subtract_fee()' with payment bigger than fee
 ///
 /// ### EXPECTED
 /// User balance is refunded with the difference
 #[test]
-fn test_substract_fee_fixed_payment_bigger_than_fee() {
+fn test_subtract_fee_fixed_payment_bigger_than_fee() {
     let mut state = FeeMarketTestState::new();
 
     let fee = state.get_fee();
@@ -781,7 +781,7 @@ fn test_substract_fee_fixed_payment_bigger_than_fee() {
         .common_setup
         .change_ownership_to_header_verifier(FEE_MARKET_ADDRESS);
 
-    state.substract_fee("Correct", None);
+    state.subtract_fee("Correct", None);
 
     state.common_setup.check_account_single_esdt(
         ESDT_SAFE_ADDRESS.to_address(),

--- a/fee-market/wasm-fee-market-view/Cargo.lock
+++ b/fee-market/wasm-fee-market-view/Cargo.lock
@@ -31,10 +31,20 @@ name = "error-messages"
 version = "0.1.0"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "structs",
+]
+
+[[package]]
 name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",
@@ -132,6 +142,15 @@ dependencies = [
  "quote",
  "radix_trie",
  "syn",
+]
+
+[[package]]
+name = "multiversx-sc-modules"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989abf1c261eb0e069035fbad362ad873bdb5cac7de1137695d07f4f9e5e036b"
+dependencies = [
+ "multiversx-sc",
 ]
 
 [[package]]

--- a/fee-market/wasm-fee-market/Cargo.lock
+++ b/fee-market/wasm-fee-market/Cargo.lock
@@ -31,10 +31,20 @@ name = "error-messages"
 version = "0.1.0"
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "multiversx-sc",
+ "multiversx-sc-modules",
+ "structs",
+]
+
+[[package]]
 name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",
@@ -132,6 +142,15 @@ dependencies = [
  "quote",
  "radix_trie",
  "syn",
+]
+
+[[package]]
+name = "multiversx-sc-modules"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989abf1c261eb0e069035fbad362ad873bdb5cac7de1137695d07f4f9e5e036b"
+dependencies = [
+ "multiversx-sc",
 ]
 
 [[package]]

--- a/fee-market/wasm-fee-market/src/lib.rs
+++ b/fee-market/wasm-fee-market/src/lib.rs
@@ -22,8 +22,8 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         setPriceAggregatorAddress => set_price_aggregator_address
         completeSetupPhase => complete_setup_phase
-        setFee => set_fee
-        removeFee => remove_fee
+        removeFee => remove_fee_during_setup_phase
+        setFee => set_fee_during_setup_phase
         getTokenFee => token_fee
         addUsersToWhitelist => add_users_to_whitelist
         removeUsersFromWhitelist => remove_users_from_whitelist

--- a/fee-market/wasm-fee-market/src/lib.rs
+++ b/fee-market/wasm-fee-market/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           10
+// Endpoints:                           12
 // Async Callback (empty):               1
-// Total number of exported functions:  13
+// Total number of exported functions:  15
 
 #![no_std]
 
@@ -22,8 +22,10 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         setPriceAggregatorAddress => set_price_aggregator_address
         completeSetupPhase => complete_setup_phase
-        removeFee => remove_fee_during_setup_phase
-        setFee => set_fee_during_setup_phase
+        removeFeeDuringSetupPhase => remove_fee_during_setup_phase
+        removeFee => remove_fee
+        setFeeDuringSetupPhase => set_fee_during_setup_phase
+        setFee => set_fee
         getTokenFee => token_fee
         addUsersToWhitelist => add_users_to_whitelist
         removeUsersFromWhitelist => remove_users_from_whitelist

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-full/Cargo.lock
@@ -71,6 +71,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe-view/Cargo.lock
@@ -71,6 +71,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
+++ b/mvx-esdt-safe/wasm-mvx-esdt-safe/Cargo.lock
@@ -71,6 +71,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sov-esdt-safe/wasm-sov-esdt-safe-full/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe-full/Cargo.lock
@@ -56,6 +56,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sov-esdt-safe/wasm-sov-esdt-safe-view/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe-view/Cargo.lock
@@ -56,6 +56,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sov-esdt-safe/wasm-sov-esdt-safe/Cargo.lock
+++ b/sov-esdt-safe/wasm-sov-esdt-safe/Cargo.lock
@@ -56,6 +56,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge-full/Cargo.lock
@@ -84,6 +84,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sovereign-forge/wasm-sovereign-forge/Cargo.lock
+++ b/sovereign-forge/wasm-sovereign-forge/Cargo.lock
@@ -84,6 +84,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",

--- a/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
+++ b/sovereign-forge/wasm-soveriegn-forge-view/Cargo.lock
@@ -84,6 +84,7 @@ name = "fee-market"
 version = "0.1.0"
 dependencies = [
  "error-messages",
+ "events",
  "multiversx-sc",
  "proxies",
  "setup-phase",


### PR DESCRIPTION
Added hash-locking for the endpoints that will be used after the completion of the sovereign setup phase. The endpoints modified are: `distribute_fees`, `set_fee`, `remove_fee`. For the latter 2, there was a copy added to be used during the setup-phase.

Now each endpoint includes `hash_of_hashes` as parameter, the ability to lock the hash of the current operation, emit failed or confirmation events and remove the executed hash from the header-verifier SC.