### PR TITLE
Modified header-verifier to emit logs

### DIFF
--- a/chain-config/src/configs.rs
+++ b/chain-config/src/configs.rs
@@ -43,7 +43,6 @@ pub trait ConfigsModule:
             );
             return;
         };
-
         if !self.is_setup_phase_complete() {
             self.complete_operation(
                 &hash_of_hashes,
@@ -52,8 +51,12 @@ pub trait ConfigsModule:
             );
             return;
         }
-
-        self.lock_operation_hash_wrapper(&config_hash, &hash_of_hashes);
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&config_hash, &hash_of_hashes)
+        {
+            self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));
+            return;
+        }
 
         if let Some(error_message) = self.is_new_config_valid(&new_config) {
             self.complete_operation(&hash_of_hashes, &config_hash, Some(error_message.into()));

--- a/chain-config/src/validator.rs
+++ b/chain-config/src/validator.rs
@@ -70,7 +70,12 @@ pub trait ValidatorModule:
             return;
         };
 
-        self.lock_operation_hash_wrapper(&config_hash, &hash_of_hashes);
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&config_hash, &hash_of_hashes)
+        {
+            self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));
+            return;
+        }
 
         self.insert_validator(
             validator_data.id,

--- a/common/common-test-setup/src/base_setup/checks.rs
+++ b/common/common-test-setup/src/base_setup/checks.rs
@@ -240,18 +240,6 @@ impl BaseSetup {
         }
     }
 
-    pub fn assert_expected_data(&self, logs: Vec<Log>, expected_data: &str) {
-        let expected_bytes = ManagedBuffer::<StaticApi>::from(expected_data).to_vec();
-
-        let found = logs.iter().any(|log| {
-            log.data
-                .iter()
-                .any(|data_item| data_item.to_vec() == expected_bytes)
-        });
-
-        assert!(found, "Expected data '{}' not found", expected_data);
-    }
-
     pub fn assert_expected_error_message(
         &mut self,
         response: Result<(), TxResponseStatus>,

--- a/common/common-test-setup/src/base_setup/contract_endpoints.rs
+++ b/common/common-test-setup/src/base_setup/contract_endpoints.rs
@@ -1,3 +1,10 @@
+use crate::constants::EXECUTED_BRIDGE_OP_EVENT;
+use crate::{
+    base_setup::init::BaseSetup,
+    constants::{CHAIN_CONFIG_ADDRESS, FEE_MARKET_ADDRESS, HEADER_VERIFIER_ADDRESS, OWNER_ADDRESS},
+};
+use multiversx_sc_scenario::imports::{BigUint, ReturnsResult};
+use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{
     api::StaticApi,
     imports::{
@@ -6,8 +13,6 @@ use multiversx_sc_scenario::{
     },
     ReturnsLogs, ScenarioTxRun,
 };
-use multiversx_sc_scenario::imports::{BigUint, ReturnsResult};
-use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use proxies::{
     chain_config_proxy::ChainConfigContractProxy, fee_market_proxy::FeeMarketProxy,
     header_verifier_proxy::HeaderverifierProxy,
@@ -15,11 +20,6 @@ use proxies::{
 use structs::fee::FeeStruct;
 use structs::generate_hash::GenerateHash;
 use structs::ValidatorData;
-use crate::{
-    base_setup::init::BaseSetup,
-    constants::{CHAIN_CONFIG_ADDRESS, FEE_MARKET_ADDRESS, HEADER_VERIFIER_ADDRESS, OWNER_ADDRESS},
-};
-use crate::constants::EXECUTED_BRIDGE_OP_EVENT;
 
 impl BaseSetup {
     pub fn register_operation(
@@ -104,11 +104,7 @@ impl BaseSetup {
         self.assert_expected_error_message(response, expected_error_message);
     }
 
-    pub fn unregister(
-        &mut self,
-        bls_key: &ManagedBuffer<StaticApi>,
-        expect_error: Option<&str>,
-    ) {
+    pub fn unregister(&mut self, bls_key: &ManagedBuffer<StaticApi>, expect_error: Option<&str>) {
         let (response, _) = self
             .world
             .tx()
@@ -127,8 +123,8 @@ impl BaseSetup {
         &mut self,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
         validator_data: &ValidatorData<StaticApi>,
-        expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
+        expected_error_log: Option<&str>,
     ) {
         let (response, logs) = self
             .world
@@ -141,8 +137,8 @@ impl BaseSetup {
             .returns(ReturnsLogs)
             .run();
 
-        self.assert_expected_error_message(response, expected_error_message);
-        self.assert_expected_log(logs, expected_custom_log, None);
+        assert!(response.is_ok());
+        self.assert_expected_log(logs, expected_custom_log, expected_error_log);
     }
 
     pub fn register_validator_operation(
@@ -167,11 +163,14 @@ impl BaseSetup {
         self.register_validator(
             &hash_of_hashes,
             &validator_data,
-            None,
             Some(EXECUTED_BRIDGE_OP_EVENT),
+            None,
         );
 
-        assert_eq!(self.get_bls_key_id(&validator_data.bls_key), validator_data.id);
+        assert_eq!(
+            self.get_bls_key_id(&validator_data.bls_key),
+            validator_data.id
+        );
     }
 
     pub fn unregister_validator(

--- a/common/proxies/src/header_verifier_proxy.rs
+++ b/common/proxies/src/header_verifier_proxy.rs
@@ -154,7 +154,7 @@ where
         self,
         hash_of_hashes: Arg0,
         operation_hash: Arg1,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, Option<ManagedBuffer<Env::Api>>> {
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, OptionalValue<ManagedBuffer<Env::Api>>> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("removeExecutedHash")

--- a/common/proxies/src/header_verifier_proxy.rs
+++ b/common/proxies/src/header_verifier_proxy.rs
@@ -129,7 +129,7 @@ where
     >(
         self,
         signature: Arg0,
-        bridge_operations_hash: Arg1,
+        hash_of_hashes: Arg1,
         operation_hash: Arg2,
         pub_keys_bitmap: Arg3,
         epoch: Arg4,
@@ -139,7 +139,7 @@ where
             .payment(NotPayable)
             .raw_call("changeValidatorSet")
             .argument(&signature)
-            .argument(&bridge_operations_hash)
+            .argument(&hash_of_hashes)
             .argument(&operation_hash)
             .argument(&pub_keys_bitmap)
             .argument(&epoch)
@@ -154,7 +154,7 @@ where
         self,
         hash_of_hashes: Arg0,
         operation_hash: Arg1,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, Option<ManagedBuffer<Env::Api>>> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("removeExecutedHash")
@@ -170,7 +170,7 @@ where
         self,
         hash_of_hashes: Arg0,
         operation_hash: Arg1,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, ()> {
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, Option<ManagedBuffer<Env::Api>>> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("lockOperationHash")

--- a/common/proxies/src/header_verifier_proxy.rs
+++ b/common/proxies/src/header_verifier_proxy.rs
@@ -170,7 +170,7 @@ where
         self,
         hash_of_hashes: Arg0,
         operation_hash: Arg1,
-    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, Option<ManagedBuffer<Env::Api>>> {
+    ) -> TxTypedCall<Env, From, To, NotPayable, Gas, OptionalValue<ManagedBuffer<Env::Api>>> {
         self.wrapped_tx
             .payment(NotPayable)
             .raw_call("lockOperationHash")

--- a/common/utils/src/lib.rs
+++ b/common/utils/src/lib.rs
@@ -18,20 +18,13 @@ pub trait UtilsModule: custom_events::CustomEventsModule {
         hash_of_hashes: &ManagedBuffer,
         hash: &ManagedBuffer,
     ) -> Option<ManagedBuffer> {
-        let result = self
-            .tx()
+        self.tx()
             .to(self.blockchain().get_owner_address())
             .typed(HeaderverifierProxy)
             .lock_operation_hash(hash_of_hashes, hash)
-            .returns(ReturnsResultUnmanaged)
-            .sync_call();
-
-        if let Some(error_message_bytes) = result {
-            let error_message_str: ManagedBuffer =
-                ManagedBuffer::new_from_bytes(&error_message_bytes);
-            return Some(error_message_str);
-        }
-        None
+            .returns(ReturnsResult)
+            .sync_call()
+            .into_option()
     }
 
     fn remove_executed_hash_wrapper(

--- a/fee-market/src/fee_operations.rs
+++ b/fee-market/src/fee_operations.rs
@@ -18,7 +18,6 @@ pub trait FeeOperationsModule:
     + fee_common::helpers::FeeCommonHelpersModule
     + fee_common::endpoints::FeeCommonEndpointsModule
 {
-    #[only_owner]
     #[endpoint(distributeFees)]
     fn distribute_fees(
         &self,

--- a/fee-market/src/fee_operations.rs
+++ b/fee-market/src/fee_operations.rs
@@ -38,8 +38,12 @@ pub trait FeeOperationsModule:
             );
             return;
         }
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash);
-
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &operation_hash, Some(lock_operation_error));
+            return;
+        }
         if let Some(err_msg) = self.validate_percentage_sum(&operation.pairs) {
             self.complete_operation(&hash_of_hashes, &operation_hash, Some(err_msg));
             return;
@@ -78,7 +82,12 @@ pub trait FeeOperationsModule:
             return;
         }
 
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &token_id_hash);
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &token_id_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &token_id_hash, Some(lock_operation_error));
+            return;
+        }
         self.token_fee(&token_id).clear();
         self.fee_enabled().set(false);
         self.complete_operation(&hash_of_hashes, &token_id_hash, None);
@@ -112,9 +121,12 @@ pub trait FeeOperationsModule:
             );
             return;
         }
-
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &fee_hash);
-
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &fee_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &fee_hash, Some(lock_operation_error));
+            return;
+        }
         if let Some(set_fee_error_msg) = self.set_fee_in_storage(&fee_struct) {
             self.complete_operation(&hash_of_hashes, &fee_hash, Some(set_fee_error_msg.into()));
             return;

--- a/fee-market/src/fee_whitelist.rs
+++ b/fee-market/src/fee_whitelist.rs
@@ -45,7 +45,12 @@ pub trait FeeWhitelistModule:
             );
             return;
         }
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash);
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &operation_hash, Some(lock_operation_error));
+            return;
+        }
         self.users_whitelist().extend(operation.users);
         self.complete_operation(&hash_of_hashes, &operation_hash, None);
     }
@@ -85,7 +90,12 @@ pub trait FeeWhitelistModule:
             );
             return;
         }
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash);
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &operation_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &operation_hash, Some(lock_operation_error));
+            return;
+        }
 
         for user in &operation.users {
             self.users_whitelist().swap_remove(&user);

--- a/fee-market/tests/fee_market_blackbox_setup.rs
+++ b/fee-market/tests/fee_market_blackbox_setup.rs
@@ -234,8 +234,8 @@ impl FeeMarketTestState {
         &mut self,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
         operation: DistributeFeesOperation<StaticApi>,
-        expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
+        expected_error_log: Option<&str>,
     ) {
         let (response, logs) = self
             .common_setup
@@ -249,11 +249,10 @@ impl FeeMarketTestState {
             .returns(ReturnsLogs)
             .run();
 
-        self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+        assert!(response.is_ok());
 
         self.common_setup
-            .assert_expected_log(logs, expected_custom_log, None);
+            .assert_expected_log(logs, expected_custom_log, expected_error_log);
     }
 
     pub fn add_users_to_whitelist_during_setup_phase(&mut self, users_vector: Vec<TestAddress>) {

--- a/fee-market/tests/fee_market_blackbox_test.rs
+++ b/fee-market/tests/fee_market_blackbox_test.rs
@@ -4,9 +4,8 @@ use common_test_setup::constants::{
     OWNER_ADDRESS, OWNER_BALANCE, SECOND_TEST_TOKEN, USER_ADDRESS, WRONG_TOKEN_ID,
 };
 use error_messages::{
-    CALLER_NOT_OWNER, CURRENT_OPERATION_NOT_REGISTERED, INVALID_FEE, INVALID_FEE_TYPE,
-    INVALID_TOKEN_ID, PAYMENT_DOES_NOT_COVER_FEE, SETUP_PHASE_NOT_COMPLETED,
-    TOKEN_NOT_ACCEPTED_AS_FEE,
+    CURRENT_OPERATION_NOT_REGISTERED, INVALID_FEE, INVALID_FEE_TYPE, INVALID_TOKEN_ID,
+    PAYMENT_DOES_NOT_COVER_FEE, SETUP_PHASE_NOT_COMPLETED, TOKEN_NOT_ACCEPTED_AS_FEE,
 };
 use fee_common::storage::FeeCommonStorageModule;
 use fee_market_blackbox_setup::*;
@@ -537,8 +536,8 @@ fn distribute_fees_setup_not_completed() {
             pairs: ManagedVec::new(),
             nonce: 0,
         },
-        Some(CALLER_NOT_OWNER),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
+        Some(SETUP_PHASE_NOT_COMPLETED),
     );
 }
 
@@ -579,8 +578,8 @@ fn distribute_fees_operation_not_registered() {
             pairs: ManagedVec::new(),
             nonce: 0,
         },
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(CURRENT_OPERATION_NOT_REGISTERED),
-        None,
     );
 }
 
@@ -650,8 +649,8 @@ fn distribute_fees_percentage_under_limit() {
     state.distribute_fees(
         &hash_of_hashes,
         operation,
-        None,
         Some(EXECUTED_BRIDGE_OP_EVENT),
+        None,
     );
 }
 
@@ -739,8 +738,8 @@ fn distribute_fees() {
     state.distribute_fees(
         &hash_of_hashes,
         operation,
-        None,
         Some(EXECUTED_BRIDGE_OP_EVENT),
+        None,
     );
 
     state.common_setup.check_account_single_esdt(

--- a/header-verifier/src/checks.rs
+++ b/header-verifier/src/checks.rs
@@ -36,7 +36,7 @@ pub trait HeaderVerifierChecksModule:
         history_mapper.contains(hash_of_hashes)
     }
 
-    fn is_operation_hash_registered(
+    fn is_hash_status_mapper_empty(
         &self,
         hash_status_mapper: &SingleValueMapper<OperationHashStatus>,
     ) -> bool {

--- a/header-verifier/src/checks.rs
+++ b/header-verifier/src/checks.rs
@@ -1,8 +1,4 @@
-use error_messages::{
-    BITMAP_LEN_DOES_NOT_MATCH_BLS_KEY_LEN, CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE,
-    CURRENT_OPERATION_NOT_REGISTERED, HASH_OF_HASHES_DOES_NOT_MATCH,
-    OUTGOING_TX_HASH_ALREADY_REGISTERED, VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
-};
+use error_messages::CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE;
 
 use crate::header_utils::OperationHashStatus;
 
@@ -16,11 +12,8 @@ pub trait HeaderVerifierChecksModule:
     + setup_phase::SetupPhaseModule
     + utils::UtilsModule
 {
-    fn require_bls_pub_keys_empty(&self, epoch: u64) {
-        require!(
-            self.bls_pub_keys(epoch).is_empty(),
-            VALIDATORS_ALREADY_REGISTERED_IN_EPOCH
-        );
+    fn is_bls_pub_keys_empty(&self, epoch: u64) -> bool {
+        self.bls_pub_keys(epoch).is_empty()
     }
 
     fn require_chain_config_setup_complete(&self, chain_config_address: &ManagedAddress) {
@@ -31,39 +24,30 @@ pub trait HeaderVerifierChecksModule:
         );
     }
 
-    fn require_bitmap_and_bls_same_length(&self, bitmap_len: usize, bls_len: usize) {
-        require!(bitmap_len == bls_len, BITMAP_LEN_DOES_NOT_MATCH_BLS_KEY_LEN);
+    fn is_bitmap_and_bls_same_length(&self, bitmap_len: usize, bls_len: usize) -> bool {
+        bitmap_len == bls_len
     }
 
-    fn require_hash_of_hashes_not_registered(
+    fn is_hash_of_hashes_registered(
         &self,
         hash_of_hashes: &ManagedBuffer,
         history_mapper: &UnorderedSetMapper<ManagedBuffer>,
-    ) {
-        require!(
-            !history_mapper.contains(hash_of_hashes),
-            OUTGOING_TX_HASH_ALREADY_REGISTERED
-        );
+    ) -> bool {
+        history_mapper.contains(hash_of_hashes)
     }
 
-    fn require_operation_hash_registered(
+    fn is_operation_hash_registered(
         &self,
         hash_status_mapper: &SingleValueMapper<OperationHashStatus>,
-    ) {
-        require!(
-            !hash_status_mapper.is_empty(),
-            CURRENT_OPERATION_NOT_REGISTERED
-        );
+    ) -> bool {
+        hash_status_mapper.is_empty()
     }
 
-    fn require_matching_hash_of_hashes(
+    fn are_hash_of_hashes_matching(
         &self,
         hash_of_hashes: &ManagedBuffer,
         computed_hash_of_hashes: &ManagedBuffer,
-    ) {
-        require!(
-            computed_hash_of_hashes.eq(hash_of_hashes),
-            HASH_OF_HASHES_DOES_NOT_MATCH
-        );
+    ) -> bool {
+        computed_hash_of_hashes.eq(hash_of_hashes)
     }
 }

--- a/header-verifier/src/header_utils.rs
+++ b/header-verifier/src/header_utils.rs
@@ -1,5 +1,5 @@
 use error_messages::{
-    BLS_KEY_NOT_REGISTERED, CALLER_NOT_FROM_CURRENT_SOVEREIGN, CHAIN_CONFIG_NOT_DEPLOYED,
+    BLS_KEY_NOT_REGISTERED, CHAIN_CONFIG_NOT_DEPLOYED, HASH_OF_HASHES_DOES_NOT_MATCH,
 };
 use structs::forge::ScArray;
 
@@ -28,7 +28,7 @@ pub trait HeaderVerifierUtilsModule:
         &self,
         transfers_hash: &ManagedBuffer,
         transfers_data: MultiValueEncoded<ManagedBuffer>,
-    ) {
+    ) -> Option<ManagedBuffer> {
         let mut transfers_hashes = ManagedBuffer::new();
         for transfer in transfers_data {
             transfers_hashes.append(&transfer);
@@ -37,7 +37,11 @@ pub trait HeaderVerifierUtilsModule:
         let hash_of_hashes_sha256 = self.crypto().sha256(&transfers_hashes);
         let hash_of_hashes = hash_of_hashes_sha256.as_managed_buffer();
 
-        self.require_matching_hash_of_hashes(transfers_hash, hash_of_hashes);
+        if !self.are_hash_of_hashes_matching(transfers_hash, hash_of_hashes) {
+            return Some(HASH_OF_HASHES_DOES_NOT_MATCH.into());
+        }
+
+        None
     }
 
     fn get_chain_config_address(&self) -> ManagedAddress {
@@ -98,7 +102,7 @@ pub trait HeaderVerifierUtilsModule:
         _bridge_operations_hash: &ManagedBuffer,
         bls_keys_bitmap: ManagedBuffer,
         bls_pub_keys: &ManagedVec<ManagedBuffer>,
-    ) {
+    ) -> Option<ManagedBuffer> {
         let _approving_validators =
             self.get_approving_validators(epoch, &bls_keys_bitmap, bls_pub_keys.len());
 
@@ -107,15 +111,14 @@ pub trait HeaderVerifierUtilsModule:
         //     bridge_operations_hash,
         //     signature,
         // );
+
+        None
     }
 
-    fn require_caller_is_from_current_sovereign(&self) {
+    fn is_caller_is_from_current_sovereign(&self) -> bool {
         let caller = self.blockchain().get_caller();
-        require!(
-            self.sovereign_contracts()
-                .iter()
-                .any(|sc| sc.address == caller),
-            CALLER_NOT_FROM_CURRENT_SOVEREIGN
-        );
+        self.sovereign_contracts()
+            .iter()
+            .any(|sc| sc.address == caller)
     }
 }

--- a/header-verifier/src/header_utils.rs
+++ b/header-verifier/src/header_utils.rs
@@ -115,7 +115,7 @@ pub trait HeaderVerifierUtilsModule:
         None
     }
 
-    fn is_caller_is_from_current_sovereign(&self) -> bool {
+    fn is_caller_from_current_sovereign(&self) -> bool {
         let caller = self.blockchain().get_caller();
         self.sovereign_contracts()
             .iter()

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -177,16 +177,16 @@ pub trait HeaderVerifierOperationsModule:
         &self,
         hash_of_hashes: ManagedBuffer,
         operation_hash: ManagedBuffer,
-    ) -> Option<ManagedBuffer> {
+    ) -> OptionalValue<ManagedBuffer> {
         if !self.is_caller_is_from_current_sovereign() {
-            return Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
+            return OptionalValue::Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
         }
 
         let operation_hash_status_mapper =
             self.operation_hash_status(&hash_of_hashes, &operation_hash);
 
         if self.is_operation_hash_registered(&operation_hash_status_mapper) {
-            return Some(CURRENT_OPERATION_NOT_REGISTERED.into());
+            return OptionalValue::Some(CURRENT_OPERATION_NOT_REGISTERED.into());
         }
 
         let is_hash_in_execution = operation_hash_status_mapper.get();
@@ -195,10 +195,10 @@ pub trait HeaderVerifierOperationsModule:
                 operation_hash_status_mapper.set(OperationHashStatus::Locked)
             }
             OperationHashStatus::Locked => {
-                return Some(CURRENT_OPERATION_ALREADY_IN_EXECUTION.into());
+                return OptionalValue::Some(CURRENT_OPERATION_ALREADY_IN_EXECUTION.into());
             }
         }
 
-        None
+        OptionalValue::None
     }
 }

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -185,7 +185,7 @@ pub trait HeaderVerifierOperationsModule:
         let operation_hash_status_mapper =
             self.operation_hash_status(&hash_of_hashes, &operation_hash);
 
-        if self.is_operation_hash_registered(&operation_hash_status_mapper) {
+        if self.is_hash_status_mapper_empty(&operation_hash_status_mapper) {
             return OptionalValue::Some(CURRENT_OPERATION_NOT_REGISTERED.into());
         }
 

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -118,7 +118,7 @@ pub trait HeaderVerifierOperationsModule:
 
             return;
         }
-        let hash_of_hashes_history_mapper = self.hash_of_hashes_history();
+        let mut hash_of_hashes_history_mapper = self.hash_of_hashes_history();
         if self.is_hash_of_hashes_registered(&hash_of_hashes, &hash_of_hashes_history_mapper) {
             self.complete_operation(
                 &hash_of_hashes,
@@ -164,7 +164,8 @@ pub trait HeaderVerifierOperationsModule:
         let new_bls_keys = self.get_bls_keys_by_id(pub_keys_id);
         self.bls_pub_keys(epoch).extend(new_bls_keys);
 
-        self.complete_operation(&hash_of_hashes, &operation_hash, None);
+        hash_of_hashes_history_mapper.insert(hash_of_hashes.clone());
+        self.execute_bridge_operation_event(&hash_of_hashes, &operation_hash, None);
     }
 
     #[endpoint(removeExecutedHash)]
@@ -172,15 +173,15 @@ pub trait HeaderVerifierOperationsModule:
         &self,
         hash_of_hashes: &ManagedBuffer,
         operation_hash: &ManagedBuffer,
-    ) -> Option<ManagedBuffer> {
+    ) -> OptionalValue<ManagedBuffer> {
         if !self.is_caller_from_current_sovereign() {
-            return Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
+            return OptionalValue::Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
         }
 
         self.operation_hash_status(hash_of_hashes, operation_hash)
             .clear();
 
-        None
+        OptionalValue::None
     }
 
     #[endpoint(lockOperationHash)]

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -1,4 +1,9 @@
-use error_messages::CURRENT_OPERATION_ALREADY_IN_EXECUTION;
+use error_messages::{
+    BITMAP_LEN_DOES_NOT_MATCH_BLS_KEY_LEN, BLS_KEY_NOT_REGISTERED, BLS_SIGNATURE_NOT_VALID,
+    CALLER_NOT_FROM_CURRENT_SOVEREIGN, CURRENT_OPERATION_ALREADY_IN_EXECUTION,
+    CURRENT_OPERATION_NOT_REGISTERED, HASH_OF_HASHES_DOES_NOT_MATCH,
+    OUTGOING_TX_HASH_ALREADY_REGISTERED, SETUP_PHASE_NOT_COMPLETED,
+};
 
 use crate::{
     checks,
@@ -25,30 +30,46 @@ pub trait HeaderVerifierOperationsModule:
         epoch: u64,
         operations_hashes: MultiValueEncoded<ManagedBuffer>,
     ) {
-        self.require_setup_complete();
+        if !self.is_setup_phase_complete() {
+            sc_panic!(SETUP_PHASE_NOT_COMPLETED);
+        }
+
         let bls_pub_keys_mapper = self.bls_pub_keys(epoch);
 
-        self.require_bitmap_and_bls_same_length(pub_keys_bitmap.len(), bls_pub_keys_mapper.len());
+        if !self.is_bitmap_and_bls_same_length(pub_keys_bitmap.len(), bls_pub_keys_mapper.len()) {
+            sc_panic!(BITMAP_LEN_DOES_NOT_MATCH_BLS_KEY_LEN);
+        }
 
         let mut hash_of_hashes_history_mapper = self.hash_of_hashes_history();
 
-        self.require_hash_of_hashes_not_registered(
-            &bridge_operations_hash,
-            &hash_of_hashes_history_mapper,
-        );
+        if self
+            .is_hash_of_hashes_registered(&bridge_operations_hash, &hash_of_hashes_history_mapper)
+        {
+            sc_panic!(OUTGOING_TX_HASH_ALREADY_REGISTERED);
+        }
 
-        self.calculate_and_check_transfers_hashes(
-            &bridge_operations_hash,
-            operations_hashes.clone(),
-        );
+        if self
+            .calculate_and_check_transfers_hashes(
+                &bridge_operations_hash,
+                operations_hashes.clone(),
+            )
+            .is_some()
+        {
+            sc_panic!(HASH_OF_HASHES_DOES_NOT_MATCH);
+        }
 
-        self.verify_bls(
-            epoch,
-            &signature,
-            &bridge_operations_hash,
-            pub_keys_bitmap,
-            &ManagedVec::from_iter(bls_pub_keys_mapper.iter()),
-        );
+        if self
+            .verify_bls(
+                epoch,
+                &signature,
+                &bridge_operations_hash,
+                pub_keys_bitmap,
+                &ManagedVec::from_iter(bls_pub_keys_mapper.iter()),
+            )
+            .is_some()
+        {
+            sc_panic!(BLS_SIGNATURE_NOT_VALID);
+        }
 
         for operation_hash in operations_hashes {
             self.operation_hash_status(&bridge_operations_hash, &operation_hash)
@@ -58,46 +79,69 @@ pub trait HeaderVerifierOperationsModule:
         hash_of_hashes_history_mapper.insert(bridge_operations_hash);
     }
 
-    // TODO: Add error events instead of panics
     #[endpoint(changeValidatorSet)]
     fn change_validator_set(
         &self,
         signature: ManagedBuffer,
-        bridge_operations_hash: ManagedBuffer,
+        hash_of_hashes: ManagedBuffer,
         operation_hash: ManagedBuffer,
         pub_keys_bitmap: ManagedBuffer,
         epoch: u64,
         pub_keys_id: MultiValueEncoded<BigUint<Self::Api>>,
     ) {
-        self.require_setup_complete();
-        self.require_bls_pub_keys_empty(epoch);
+        if !self.is_setup_phase_complete() {
+            self.complete_operation(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(SETUP_PHASE_NOT_COMPLETED.into()),
+            );
 
+            return;
+        }
+        if !self.is_bls_pub_keys_empty(epoch) {
+            self.complete_operation(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(BLS_KEY_NOT_REGISTERED.into()),
+            );
+
+            return;
+        }
         let bls_keys_previous_epoch = self.bls_pub_keys(epoch - 1);
+        if !self.is_bitmap_and_bls_same_length(pub_keys_bitmap.len(), bls_keys_previous_epoch.len())
+        {
+            self.complete_operation(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(BITMAP_LEN_DOES_NOT_MATCH_BLS_KEY_LEN.into()),
+            );
 
-        self.require_bitmap_and_bls_same_length(
-            pub_keys_bitmap.len(),
-            bls_keys_previous_epoch.len(),
-        );
+            return;
+        }
+        let hash_of_hashes_history_mapper = self.hash_of_hashes_history();
+        if self.is_hash_of_hashes_registered(&hash_of_hashes, &hash_of_hashes_history_mapper) {
+            self.complete_operation(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(OUTGOING_TX_HASH_ALREADY_REGISTERED.into()),
+            );
 
-        let mut hash_of_hashes_history_mapper = self.hash_of_hashes_history();
-
-        self.require_hash_of_hashes_not_registered(
-            &bridge_operations_hash,
-            &hash_of_hashes_history_mapper,
-        );
+            return;
+        }
 
         let mut operations_hashes = MultiValueEncoded::new();
         operations_hashes.push(operation_hash.clone());
 
-        self.calculate_and_check_transfers_hashes(
-            &bridge_operations_hash,
-            operations_hashes.clone(),
-        );
+        if let Some(error_message) =
+            self.calculate_and_check_transfers_hashes(&hash_of_hashes, operations_hashes.clone())
+        {
+            self.complete_operation(&hash_of_hashes, &operation_hash, Some(error_message));
+        }
 
         self.verify_bls(
             epoch - 1, // Use the validator signatures from the last epoch
             &signature,
-            &bridge_operations_hash,
+            &hash_of_hashes,
             pub_keys_bitmap,
             &ManagedVec::from_iter(bls_keys_previous_epoch.iter()),
         );
@@ -109,26 +153,41 @@ pub trait HeaderVerifierOperationsModule:
         let new_bls_keys = self.get_bls_keys_by_id(pub_keys_id);
         self.bls_pub_keys(epoch).extend(new_bls_keys);
 
-        hash_of_hashes_history_mapper.insert(bridge_operations_hash.clone());
-        self.execute_bridge_operation_event(&bridge_operations_hash, &operation_hash, None);
+        self.complete_operation(&hash_of_hashes, &operation_hash, None);
     }
 
     #[endpoint(removeExecutedHash)]
-    fn remove_executed_hash(&self, hash_of_hashes: &ManagedBuffer, operation_hash: &ManagedBuffer) {
-        self.require_caller_is_from_current_sovereign();
+    fn remove_executed_hash(
+        &self,
+        hash_of_hashes: &ManagedBuffer,
+        operation_hash: &ManagedBuffer,
+    ) -> Option<ManagedBuffer> {
+        if !self.is_caller_is_from_current_sovereign() {
+            return Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
+        }
 
         self.operation_hash_status(hash_of_hashes, operation_hash)
             .clear();
+
+        None
     }
 
     #[endpoint(lockOperationHash)]
-    fn lock_operation_hash(&self, hash_of_hashes: ManagedBuffer, operation_hash: ManagedBuffer) {
-        self.require_caller_is_from_current_sovereign();
+    fn lock_operation_hash(
+        &self,
+        hash_of_hashes: ManagedBuffer,
+        operation_hash: ManagedBuffer,
+    ) -> Option<ManagedBuffer> {
+        if !self.is_caller_is_from_current_sovereign() {
+            return Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
+        }
 
         let operation_hash_status_mapper =
             self.operation_hash_status(&hash_of_hashes, &operation_hash);
 
-        self.require_operation_hash_registered(&operation_hash_status_mapper);
+        if self.is_operation_hash_registered(&operation_hash_status_mapper) {
+            return Some(CURRENT_OPERATION_NOT_REGISTERED.into());
+        }
 
         let is_hash_in_execution = operation_hash_status_mapper.get();
         match is_hash_in_execution {
@@ -136,8 +195,10 @@ pub trait HeaderVerifierOperationsModule:
                 operation_hash_status_mapper.set(OperationHashStatus::Locked)
             }
             OperationHashStatus::Locked => {
-                sc_panic!(CURRENT_OPERATION_ALREADY_IN_EXECUTION)
+                return Some(CURRENT_OPERATION_ALREADY_IN_EXECUTION.into());
             }
         }
+
+        None
     }
 }

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -173,7 +173,7 @@ pub trait HeaderVerifierOperationsModule:
         hash_of_hashes: &ManagedBuffer,
         operation_hash: &ManagedBuffer,
     ) -> Option<ManagedBuffer> {
-        if !self.is_caller_is_from_current_sovereign() {
+        if !self.is_caller_from_current_sovereign() {
             return Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
         }
 
@@ -189,7 +189,7 @@ pub trait HeaderVerifierOperationsModule:
         hash_of_hashes: ManagedBuffer,
         operation_hash: ManagedBuffer,
     ) -> OptionalValue<ManagedBuffer> {
-        if !self.is_caller_is_from_current_sovereign() {
+        if !self.is_caller_from_current_sovereign() {
             return OptionalValue::Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN.into());
         }
 

--- a/header-verifier/tests/header_verifier_blackbox_setup.rs
+++ b/header-verifier/tests/header_verifier_blackbox_setup.rs
@@ -5,8 +5,8 @@ use common_test_setup::constants::{
 };
 use multiversx_sc::api::ManagedTypeApi;
 use multiversx_sc::types::{
-    BigUint, ManagedBuffer, MultiValueEncoded, ReturnsHandledOrError, ReturnsResultUnmanaged,
-    TestSCAddress,
+    BigUint, ManagedBuffer, MultiValueEncoded, ReturnsHandledOrError, ReturnsResult,
+    ReturnsResultUnmanaged, TestSCAddress,
 };
 use multiversx_sc_scenario::ReturnsLogs;
 use multiversx_sc_scenario::{
@@ -92,8 +92,9 @@ impl HeaderVerifierTestState {
             .to(HEADER_VERIFIER_ADDRESS)
             .typed(HeaderverifierProxy)
             .remove_executed_hash(hash_of_hashes, operation_hash)
-            .returns(ReturnsResultUnmanaged)
-            .run();
+            .returns(ReturnsResult)
+            .run()
+            .into_option();
 
         // TODO: create a separate common function
         match response {
@@ -101,13 +102,8 @@ impl HeaderVerifierTestState {
                 expected_result.is_none(),
                 "Transaction was successful, but expected error"
             ),
-            Some(error_message_bytes) => {
-                let error_message_str: ManagedBuffer<StaticApi> =
-                    ManagedBuffer::new_from_bytes(&error_message_bytes);
-                assert_eq!(
-                    expected_result,
-                    Some(error_message_str.to_string().as_str())
-                );
+            Some(error_message) => {
+                assert_eq!(expected_result, Some(error_message.to_string().as_str()));
             }
         };
     }

--- a/header-verifier/tests/header_verifier_blackbox_setup.rs
+++ b/header-verifier/tests/header_verifier_blackbox_setup.rs
@@ -5,7 +5,8 @@ use common_test_setup::constants::{
 };
 use multiversx_sc::api::ManagedTypeApi;
 use multiversx_sc::types::{
-    BigUint, ManagedBuffer, MultiValueEncoded, ReturnsHandledOrError, TestSCAddress,
+    BigUint, ManagedBuffer, MultiValueEncoded, ReturnsHandledOrError, ReturnsResultUnmanaged,
+    TestSCAddress,
 };
 use multiversx_sc_scenario::ReturnsLogs;
 use multiversx_sc_scenario::{
@@ -91,15 +92,23 @@ impl HeaderVerifierTestState {
             .to(HEADER_VERIFIER_ADDRESS)
             .typed(HeaderverifierProxy)
             .remove_executed_hash(hash_of_hashes, operation_hash)
-            .returns(ReturnsHandledOrError::new())
+            .returns(ReturnsResultUnmanaged)
             .run();
 
+        // TODO: create a separate common function
         match response {
-            Ok(_) => assert!(
+            None => assert!(
                 expected_result.is_none(),
                 "Transaction was successful, but expected error"
             ),
-            Err(error) => assert_eq!(expected_result, Some(error.message.as_str())),
+            Some(error_message_bytes) => {
+                let error_message_str: ManagedBuffer<StaticApi> =
+                    ManagedBuffer::new_from_bytes(&error_message_bytes);
+                assert_eq!(
+                    expected_result,
+                    Some(error_message_str.to_string().as_str())
+                );
+            }
         };
     }
 
@@ -118,15 +127,22 @@ impl HeaderVerifierTestState {
             .to(HEADER_VERIFIER_ADDRESS)
             .typed(HeaderverifierProxy)
             .lock_operation_hash(hash_of_hashes, operation_hash)
-            .returns(ReturnsHandledOrError::new())
+            .returns(ReturnsResultUnmanaged)
             .run();
 
         match response {
-            Ok(_) => assert!(
+            None => assert!(
                 expected_result.is_none(),
                 "Transaction was successful, but expected error"
             ),
-            Err(error) => assert_eq!(expected_result, Some(error.message.as_str())),
+            Some(error_message_bytes) => {
+                let error_message_str: ManagedBuffer<StaticApi> =
+                    ManagedBuffer::new_from_bytes(&error_message_bytes);
+                assert_eq!(
+                    expected_result,
+                    Some(error_message_str.to_string().as_str())
+                );
+            }
         };
     }
 
@@ -139,8 +155,8 @@ impl HeaderVerifierTestState {
         epoch: u64,
         pub_keys_bitmap: &ManagedBuffer<StaticApi>,
         validator_set: MultiValueEncoded<StaticApi, BigUint<StaticApi>>,
-        expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
+        expected_log_error: Option<&str>,
     ) {
         let (logs, response) = self
             .common_setup
@@ -161,11 +177,14 @@ impl HeaderVerifierTestState {
             .returns(ReturnsHandledOrError::new())
             .run();
 
-        self.common_setup
-            .assert_expected_error_message(response, expected_error_message);
+        assert!(
+            response.is_ok(),
+            "Transaction failed with error: {:?}",
+            response.err()
+        );
 
         self.common_setup
-            .assert_expected_log(logs, expected_custom_log, None);
+            .assert_expected_log(logs, expected_custom_log, expected_log_error);
     }
 
     pub fn generate_bridge_operation_struct(

--- a/header-verifier/tests/header_verifier_blackbox_setup.rs
+++ b/header-verifier/tests/header_verifier_blackbox_setup.rs
@@ -130,7 +130,7 @@ impl HeaderVerifierTestState {
             .returns(ReturnsResultUnmanaged)
             .run();
 
-        match response {
+        match response.into_option() {
             None => assert!(
                 expected_result.is_none(),
                 "Transaction was successful, but expected error"

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -589,7 +589,7 @@ fn test_change_validator_set() {
 /// H-VERIFIER_CHANGE_VALIDATORS_FAIL
 ///
 /// ### ACTION
-/// Call 'change_validators_set()' before registering the operation
+/// Call 'change_validator_set()' before registering the operation
 ///
 /// ### EXPECTED
 /// Error OUTGOING_TX_HASH_ALREADY_REGISTERED

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -16,6 +16,7 @@ use multiversx_sc::{
     types::{ManagedBuffer, MultiEgldOrEsdtPayment, MultiValueEncoded},
 };
 use multiversx_sc_scenario::api::StaticApi;
+use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{DebugApi, ScenarioTxWhitebox};
 use structs::configs::SovereignConfig;
 use structs::{forge::ScArray, ValidatorData};
@@ -616,17 +617,25 @@ fn test_change_validator_set_operation_already_registered() {
         .complete_header_verifier_setup_phase(None);
 
     let operation_1 = ManagedBuffer::from("operation_1");
-    let operation_2 = ManagedBuffer::from("operation_2");
-    let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
+    let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&operation_1.to_vec()));
 
     let bitmap = ManagedBuffer::new_from_bytes(&[1]);
 
-    state.register_operations(operation.clone(), bitmap.clone(), 0, None);
+    state.change_validator_set(
+        &ManagedBuffer::new(),
+        &hash_of_hashes,
+        &operation_1,
+        1,
+        &bitmap,
+        MultiValueEncoded::new(),
+        Some(EXECUTED_BRIDGE_OP_EVENT),
+        None,
+    );
 
     state.change_validator_set(
         &ManagedBuffer::new(),
-        &operation.bridge_operation_hash,
-        &operation.operations_hashes.to_vec().get(0),
+        &hash_of_hashes,
+        &operation_1,
         1,
         &bitmap,
         MultiValueEncoded::new(),

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -52,10 +52,11 @@ fn register_bridge_operation_setup_not_completed() {
     let operation_1 = ManagedBuffer::from("operation_1");
     let operation_2 = ManagedBuffer::from("operation_2");
     let operation = state.generate_bridge_operation_struct(vec![&operation_1, &operation_2]);
+    let bitmap = ManagedBuffer::new_from_bytes(&[1]);
 
     state.register_operations(
         operation.clone(),
-        ManagedBuffer::new(),
+        bitmap,
         0,
         Some(SETUP_PHASE_NOT_COMPLETED),
     );
@@ -575,8 +576,8 @@ fn test_change_validator_set() {
         epoch_for_new_set,
         &bitmap,
         validator_set,
-        None,
         Some(EXECUTED_BRIDGE_OP_EVENT),
+        None,
     );
 
     state
@@ -588,7 +589,7 @@ fn test_change_validator_set() {
 /// H-VERIFIER_CHANGE_VALIDATORS_FAIL
 ///
 /// ### ACTION
-/// Call 'change_validators_set()' after registering the operation
+/// Call 'change_validators_set()' before registering the operation
 ///
 /// ### EXPECTED
 /// Error OUTGOING_TX_HASH_ALREADY_REGISTERED
@@ -629,8 +630,8 @@ fn test_change_validator_set_operation_already_registered() {
         1,
         &bitmap,
         MultiValueEncoded::new(),
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(OUTGOING_TX_HASH_ALREADY_REGISTERED),
-        None,
     );
 }
 
@@ -699,12 +700,11 @@ fn test_change_multiple_validator_sets() {
             epoch,
             &bitmap,
             validator_set,
-            None,
             Some(EXECUTED_BRIDGE_OP_EVENT),
+            None,
         );
 
-        let mut bls_keys: ManagedVec<StaticApi, ManagedBuffer<StaticApi>> =
-            ManagedVec::new();
+        let mut bls_keys: ManagedVec<StaticApi, ManagedBuffer<StaticApi>> = ManagedVec::new();
         bls_keys.push(validator_bls_key);
         state
             .common_setup

--- a/mvx-esdt-safe/src/execute.rs
+++ b/mvx-esdt-safe/src/execute.rs
@@ -139,7 +139,7 @@ pub trait ExecuteModule:
                 self.complete_operation(
                     hash_of_hashes,
                     &operation_tuple.op_hash,
-                    Some(ManagedBuffer::from(DEPOSIT_AMOUNT_NOT_ENOUGH)),
+                    Some(DEPOSIT_AMOUNT_NOT_ENOUGH.into()),
                 );
                 return None;
             }

--- a/mvx-esdt-safe/src/lib.rs
+++ b/mvx-esdt-safe/src/lib.rs
@@ -78,7 +78,6 @@ pub trait MvxEsdtSafe:
             );
             return;
         }
-
         if !self.is_setup_phase_complete() {
             self.complete_operation(
                 &hash_of_hashes,
@@ -87,15 +86,19 @@ pub trait MvxEsdtSafe:
             );
             return;
         }
-
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &config_hash);
-
+        if let Some(lock_operation_error) =
+            self.lock_operation_hash_wrapper(&hash_of_hashes, &config_hash)
+        {
+            self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));
+            return;
+        }
         if let Some(error_message) = self.is_esdt_safe_config_valid(&new_config) {
             self.complete_operation(
                 &hash_of_hashes,
                 &config_hash,
                 Some(ManagedBuffer::from(error_message)),
             );
+            return;
         } else {
             self.esdt_safe_config().set(new_config);
             self.complete_operation(&hash_of_hashes, &config_hash, None);

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_setup.rs
@@ -164,7 +164,6 @@ impl MvxEsdtSafeTestState {
         &mut self,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
         new_config: EsdtSafeConfig<StaticApi>,
-        err_message: Option<&str>,
         expected_custom_log: Option<&str>,
         expected_log_error: Option<&str>,
     ) {
@@ -180,10 +179,7 @@ impl MvxEsdtSafeTestState {
             .returns(ReturnsLogs)
             .run();
 
-        println!("Update ESDT Safe Config Result: {:?}", logs);
-
-        self.common_setup
-            .assert_expected_error_message(result, err_message);
+        assert!(result.is_ok());
 
         self.common_setup
             .assert_expected_log(logs, expected_custom_log, expected_log_error);
@@ -330,9 +326,7 @@ impl MvxEsdtSafeTestState {
         &mut self,
         hash_of_hashes: &ManagedBuffer<StaticApi>,
         operation: &Operation<StaticApi>,
-        expected_error_message: Option<&str>,
         expected_custom_log: Option<&str>,
-        expected_custom_log_data: Option<&str>,
         expected_log_error: Option<&str>,
     ) {
         let (logs, result) = self
@@ -347,19 +341,13 @@ impl MvxEsdtSafeTestState {
             .returns(ReturnsHandledOrError::new())
             .run();
 
-        self.common_setup
-            .assert_expected_error_message(result, expected_error_message);
+        assert!(result.is_ok());
 
         self.common_setup.assert_expected_log(
             logs.clone(),
             expected_custom_log,
             expected_log_error,
         );
-
-        if let Some(custom_log_data) = expected_custom_log_data {
-            self.common_setup
-                .assert_expected_data(logs, custom_log_data);
-        };
     }
 
     pub fn complete_setup_phase(

--- a/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
+++ b/mvx-esdt-safe/tests/mvx_esdt_safe_blackbox_tests.rs
@@ -1,9 +1,10 @@
+use common_test_setup::base_setup::helpers::BLSKey;
 use common_test_setup::base_setup::init::RegisterTokenArgs;
 use common_test_setup::constants::{
     CROWD_TOKEN_ID, DEPOSIT_EVENT, ESDT_SAFE_ADDRESS, EXECUTED_BRIDGE_OP_EVENT, FEE_MARKET_ADDRESS,
     FEE_TOKEN, FIRST_TEST_TOKEN, HEADER_VERIFIER_ADDRESS, ONE_HUNDRED_MILLION,
-    ONE_HUNDRED_THOUSAND, OWNER_ADDRESS, SC_CALL_EVENT, SECOND_TEST_TOKEN,
-    SOV_TOKEN, TESTING_SC_ADDRESS, USER_ADDRESS,
+    ONE_HUNDRED_THOUSAND, OWNER_ADDRESS, SC_CALL_EVENT, SECOND_TEST_TOKEN, SOV_TOKEN,
+    TESTING_SC_ADDRESS, USER_ADDRESS,
 };
 use cross_chain::storage::CrossChainStorage;
 use cross_chain::{DEFAULT_ISSUE_COST, MAX_GAS_PER_TRANSACTION};
@@ -28,7 +29,6 @@ use multiversx_sc::{
 };
 use multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use multiversx_sc_scenario::{api::StaticApi, ScenarioTxWhitebox};
-use common_test_setup::base_setup::helpers::BLSKey;
 use mvx_esdt_safe::bridging_mechanism::{BridgingMechanism, TRUSTED_TOKEN_IDS};
 use mvx_esdt_safe_blackbox_setup::MvxEsdtSafeTestState;
 use setup_phase::SetupPhaseModule;
@@ -1361,10 +1361,8 @@ fn test_execute_operation_no_chain_config_registered() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN),
-        None,
-        None,
-        None,
     );
 
     state
@@ -1409,10 +1407,8 @@ fn test_execute_operation_no_esdt_safe_registered() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(CALLER_NOT_FROM_CURRENT_SOVEREIGN),
-        None,
-        None,
-        None,
     );
 
     state
@@ -1465,11 +1461,9 @@ fn test_execute_operation_success() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -1501,9 +1495,7 @@ fn test_execute_operation_success() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -1557,11 +1549,9 @@ fn test_execute_operation_with_native_token_success() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -1593,9 +1583,7 @@ fn test_execute_operation_with_native_token_success() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -1648,11 +1636,9 @@ fn test_execute_operation_burn_mechanism_without_deposit_cannot_subtract() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -1682,9 +1668,7 @@ fn test_execute_operation_burn_mechanism_without_deposit_cannot_subtract() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -1737,11 +1721,9 @@ fn execute_operation_only_transfer_data_no_fee() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -1770,9 +1752,7 @@ fn execute_operation_only_transfer_data_no_fee() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -1821,11 +1801,9 @@ fn test_execute_operation_success_burn_mechanism() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -1868,9 +1846,7 @@ fn test_execute_operation_success_burn_mechanism() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -1932,11 +1908,9 @@ fn test_deposit_execute_switch_mechanism() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -2022,9 +1996,7 @@ fn test_deposit_execute_switch_mechanism() {
     state.execute_operation(
         &hash_of_hashes_one,
         &operation_one,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -2103,9 +2075,7 @@ fn test_deposit_execute_switch_mechanism() {
     state.execute_operation(
         &hash_of_hashes_two,
         &operation_two,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -2196,11 +2166,9 @@ fn test_execute_operation_no_payments() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -2234,9 +2202,7 @@ fn test_execute_operation_no_payments() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
-        None,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 
@@ -2264,11 +2230,9 @@ fn test_execute_operation_no_payments_failed_event() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -2317,10 +2281,8 @@ fn test_execute_operation_no_payments_failed_event() {
     state.execute_operation(
         &hash_of_hashes,
         &operation,
-        None,
-        Some("executedBridgeOp"),
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some("invalid function (not found)"),
-        None,
     );
 
     state
@@ -2506,7 +2468,6 @@ fn test_update_config_setup_phase_not_completed() {
     state.update_esdt_safe_config(
         &ManagedBuffer::new(),
         new_config,
-        None,
         Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(SETUP_PHASE_NOT_COMPLETED),
     );
@@ -2541,9 +2502,8 @@ fn test_update_config_operation_not_registered() {
     state.update_esdt_safe_config(
         &ManagedBuffer::new(),
         new_config,
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(CURRENT_OPERATION_NOT_REGISTERED),
-        None,
-        None,
     );
 }
 
@@ -2565,11 +2525,9 @@ fn test_update_config_invalid_config() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -2602,8 +2560,7 @@ fn test_update_config_invalid_config() {
     state.update_esdt_safe_config(
         &hash_of_hashes,
         new_config,
-        None,
-        Some("executedBridgeOp"),
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         Some(MAX_GAS_LIMIT_PER_TX_EXCEEDED),
     );
 }
@@ -2626,11 +2583,9 @@ fn test_update_config() {
         .common_setup
         .deploy_chain_config(OptionalValue::None, None);
 
-    state.common_setup.register(
-        &BLSKey::random(),
-        &MultiEgldOrEsdtPayment::new(),
-        None,
-    );
+    state
+        .common_setup
+        .register(&BLSKey::random(), &MultiEgldOrEsdtPayment::new(), None);
 
     state.common_setup.complete_chain_config_setup_phase(None);
 
@@ -2664,8 +2619,7 @@ fn test_update_config() {
     state.update_esdt_safe_config(
         &hash_of_hashes,
         new_config,
-        None,
-        Some("executedBridgeOp"),
+        Some(EXECUTED_BRIDGE_OP_EVENT),
         None,
     );
 


### PR DESCRIPTION
Since the Header-Verifier smart contract will interactor with outgoing operations from the Sovereign Chain to the MultiversX mainchain, it is needed for the endpoints to either emit logs or error messages to not fail transactions.

This PR implements this logic, the endpoints right now will behave as this:
* `register_bridge_operations` will panic
* `change_validator_set` will emit bridge operation event + optional error message
* `lock/remove operation hash` will return an `OptionalValue` depicting the error message (if there was any)

