### PR TITLE
Small fixes

### DIFF
--- a/chain-config/src/configs.rs
+++ b/chain-config/src/configs.rs
@@ -57,8 +57,8 @@ pub trait ConfigsModule:
             return;
         }
         if let Some(lock_operation_error) = self.lock_operation_hash_wrapper(
-            &config_hash,
             &hash_of_hashes,
+            &config_hash,
             update_config_operation.nonce,
         ) {
             self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));

--- a/chain-config/src/validator.rs
+++ b/chain-config/src/validator.rs
@@ -71,8 +71,8 @@ pub trait ValidatorModule:
         };
 
         if let Some(lock_operation_error) = self.lock_operation_hash_wrapper(
-            &config_hash,
             &hash_of_hashes,
+            &config_hash,
             validator_operation.nonce,
         ) {
             self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));

--- a/chain-config/src/validator.rs
+++ b/chain-config/src/validator.rs
@@ -137,7 +137,14 @@ pub trait ValidatorModule:
             return;
         };
 
-        self.lock_operation_hash_wrapper(&hash_of_hashes, &config_hash, validator_operation.nonce);
+        if let Some(lock_operation_error) = self.lock_operation_hash_wrapper(
+            &hash_of_hashes,
+            &config_hash,
+            validator_operation.nonce,
+        ) {
+            self.complete_operation(&hash_of_hashes, &config_hash, Some(lock_operation_error));
+            return;
+        }
 
         let validator_info_mapper = self.validator_info(&validator_operation.validator_data.id);
         if validator_info_mapper.is_empty() {

--- a/common/cross-chain/src/deposit_common.rs
+++ b/common/cross-chain/src/deposit_common.rs
@@ -69,7 +69,7 @@ pub trait DepositCommonModule:
         let caller = self.blockchain().get_caller();
         self.refund_tokens(&caller, refundable_payments);
 
-        let tx_nonce = self.get_and_save_next_tx_id();
+        let tx_nonce = self.get_current_and_increment_tx_nonce();
 
         if payments.is_empty() {
             self.sc_call_event(
@@ -247,11 +247,13 @@ pub trait DepositCommonModule:
     }
 
     #[inline]
-    fn get_and_save_next_tx_id(&self) -> TxNonce {
-        self.last_tx_nonce().update(|last_tx_nonce| {
-            *last_tx_nonce += 1;
-            *last_tx_nonce
-        })
+    fn get_current_and_increment_tx_nonce(&self) -> TxNonce {
+        let last_tx_nonce_mapper = self.last_tx_nonce();
+        let current_nonce = last_tx_nonce_mapper.get();
+        let next_nonce = current_nonce + 1;
+        last_tx_nonce_mapper.set(next_nonce);
+
+        current_nonce
     }
 
     #[inline]

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -146,6 +146,7 @@ pub const ADDITIONAL_STAKE_ZERO_VALUE: &str = "Additional stake cannot be a zero
 pub const ADDITIONAL_STAKE_NOT_REQUIRED: &str = "Additional stake was provided but is not required";
 pub const INVALID_BLS_KEY_FOR_CALLER: &str = "Invalid BLS key for caller";
 pub const GENESIS_VALIDATORS_ALREADY_SET: &str = "Genesis Validator were already set";
+pub const GENESIS_VALIDATORS_NOT_SET: &str = "Genesis Validator were not set";
 pub const CALLER_NOT_CHAIN_CONFIG: &str = "Only Chain-Config SC can call this endpoint";
 pub const CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE: &str =
     "The Chain-Config SC setup phase is not completed";

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -147,6 +147,7 @@ pub const ADDITIONAL_STAKE_NOT_REQUIRED: &str = "Additional stake was provided b
 pub const INVALID_BLS_KEY_FOR_CALLER: &str = "Invalid BLS key for caller";
 pub const GENESIS_VALIDATORS_ALREADY_SET: &str = "Genesis validators were already set";
 pub const GENESIS_VALIDATORS_NOT_SET: &str = "Genesis validators were not set";
+pub const INVALID_EPOCH: &str = "Cannot change the validator set for the genesis epoch";
 pub const CALLER_NOT_CHAIN_CONFIG: &str = "Only Chain-Config SC can call this endpoint";
 pub const CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE: &str =
     "The Chain-Config SC setup phase is not completed";

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -40,7 +40,9 @@ pub const ESDT_SAFE_CONFIG_NOT_SET: &str = "There is no config set for this cont
 pub const ESDT_SAFE_NOT_DEPLOYED: &str =
     "The ESDT-Safe SC is not deployed, you skipped the second phase";
 pub const ESDT_SAFE_STILL_PAUSED: &str = "Cannot create transaction while paused";
+pub const EXPECTED_MAPPED_TOKEN: &str = "Expected mapped token, got None";
 pub const FAILED_TO_PARSE_AS_NUMBER: &str = "Failed to parse actual amount as number";
+pub const FAILED_TO_REGISTER_SOVEREIGN_TOKEN: &str = "Failed to register sovereign token";
 pub const FEE_MARKET_ALREADY_DEPLOYED: &str = "The Fee-Market SC is already deployed";
 pub const FEE_MARKET_NOT_DEPLOYED: &str = "The Fee-Market SC is not deployed";
 pub const FEE_MARKET_NOT_SET: &str = "There is no Fee-Market address set";

--- a/common/error-messages/src/lib.rs
+++ b/common/error-messages/src/lib.rs
@@ -145,8 +145,8 @@ pub const EMPTY_ADDITIONAL_STAKE: &str = "Additional stake was sent as an empty 
 pub const ADDITIONAL_STAKE_ZERO_VALUE: &str = "Additional stake cannot be a zero value";
 pub const ADDITIONAL_STAKE_NOT_REQUIRED: &str = "Additional stake was provided but is not required";
 pub const INVALID_BLS_KEY_FOR_CALLER: &str = "Invalid BLS key for caller";
-pub const GENESIS_VALIDATORS_ALREADY_SET: &str = "Genesis Validator were already set";
-pub const GENESIS_VALIDATORS_NOT_SET: &str = "Genesis Validator were not set";
+pub const GENESIS_VALIDATORS_ALREADY_SET: &str = "Genesis validators were already set";
+pub const GENESIS_VALIDATORS_NOT_SET: &str = "Genesis validators were not set";
 pub const CALLER_NOT_CHAIN_CONFIG: &str = "Only Chain-Config SC can call this endpoint";
 pub const CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE: &str =
     "The Chain-Config SC setup phase is not completed";

--- a/common/fee-common/src/helpers.rs
+++ b/common/fee-common/src/helpers.rs
@@ -219,9 +219,11 @@ pub trait FeeCommonHelpersModule:
 
         match fee {
             Some(fee_struct) => {
-                let _ = self.set_fee_in_storage(&fee_struct);
+                if let Some(err_msg) = self.set_fee_in_storage(&fee_struct) {
+                    sc_panic!(err_msg);
+                }
             }
-            _ => self.fee_enabled().set(false),
+            None => self.fee_enabled().set(false),
         }
     }
 }

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -1,8 +1,8 @@
 use error_messages::{
     CALLER_NOT_FROM_CURRENT_SOVEREIGN, CURRENT_OPERATION_ALREADY_IN_EXECUTION,
     CURRENT_OPERATION_NOT_REGISTERED, GENESIS_VALIDATORS_NOT_SET, HASH_OF_HASHES_DOES_NOT_MATCH,
-    INCORRECT_OPERATION_NONCE, OUTGOING_TX_HASH_ALREADY_REGISTERED, SETUP_PHASE_NOT_COMPLETED,
-    VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
+    INCORRECT_OPERATION_NONCE, INVALID_EPOCH, OUTGOING_TX_HASH_ALREADY_REGISTERED,
+    SETUP_PHASE_NOT_COMPLETED, VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
 };
 use structs::{aliases::TxNonce, OperationHashStatus};
 
@@ -81,6 +81,16 @@ pub trait HeaderVerifierOperationsModule:
                 &hash_of_hashes,
                 &operation_hash,
                 Some(SETUP_PHASE_NOT_COMPLETED.into()),
+            );
+
+            return;
+        }
+
+        if epoch == 0 {
+            self.execute_bridge_operation_event(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(INVALID_EPOCH.into()),
             );
 
             return;

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -1,8 +1,8 @@
 use error_messages::{
     CALLER_NOT_FROM_CURRENT_SOVEREIGN, CURRENT_OPERATION_ALREADY_IN_EXECUTION,
-    CURRENT_OPERATION_NOT_REGISTERED, GENESIS_VALIDATORS_NOT_SET, HASH_OF_HASHES_DOES_NOT_MATCH,
-    INCORRECT_OPERATION_NONCE, INVALID_EPOCH, OUTGOING_TX_HASH_ALREADY_REGISTERED,
-    SETUP_PHASE_NOT_COMPLETED, VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
+    CURRENT_OPERATION_NOT_REGISTERED, HASH_OF_HASHES_DOES_NOT_MATCH, INCORRECT_OPERATION_NONCE,
+    INVALID_EPOCH, OUTGOING_TX_HASH_ALREADY_REGISTERED, SETUP_PHASE_NOT_COMPLETED,
+    VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
 };
 use structs::{aliases::TxNonce, OperationHashStatus};
 
@@ -91,16 +91,6 @@ pub trait HeaderVerifierOperationsModule:
                 &hash_of_hashes,
                 &operation_hash,
                 Some(INVALID_EPOCH.into()),
-            );
-
-            return;
-        }
-
-        if self.bls_pub_keys(0).is_empty() {
-            self.execute_bridge_operation_event(
-                &hash_of_hashes,
-                &operation_hash,
-                Some(GENESIS_VALIDATORS_NOT_SET.into()),
             );
 
             return;

--- a/header-verifier/src/operations.rs
+++ b/header-verifier/src/operations.rs
@@ -1,7 +1,7 @@
 use error_messages::{
     CALLER_NOT_FROM_CURRENT_SOVEREIGN, CURRENT_OPERATION_ALREADY_IN_EXECUTION,
-    CURRENT_OPERATION_NOT_REGISTERED, HASH_OF_HASHES_DOES_NOT_MATCH, INCORRECT_OPERATION_NONCE,
-    OUTGOING_TX_HASH_ALREADY_REGISTERED, SETUP_PHASE_NOT_COMPLETED,
+    CURRENT_OPERATION_NOT_REGISTERED, GENESIS_VALIDATORS_NOT_SET, HASH_OF_HASHES_DOES_NOT_MATCH,
+    INCORRECT_OPERATION_NONCE, OUTGOING_TX_HASH_ALREADY_REGISTERED, SETUP_PHASE_NOT_COMPLETED,
     VALIDATORS_ALREADY_REGISTERED_IN_EPOCH,
 };
 use structs::{aliases::TxNonce, OperationHashStatus};
@@ -85,6 +85,17 @@ pub trait HeaderVerifierOperationsModule:
 
             return;
         }
+
+        if self.bls_pub_keys(0).is_empty() {
+            self.execute_bridge_operation_event(
+                &hash_of_hashes,
+                &operation_hash,
+                Some(GENESIS_VALIDATORS_NOT_SET.into()),
+            );
+
+            return;
+        }
+
         if !self.is_bls_pub_keys_empty(epoch) {
             self.execute_bridge_operation_event(
                 &hash_of_hashes,

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -13,7 +13,7 @@ use header_verifier::header_utils::HeaderVerifierUtilsModule;
 use header_verifier::storage::HeaderVerifierStorageModule;
 use header_verifier_blackbox_setup::*;
 use multiversx_sc::imports::{BigUint, ManagedVec, StorageClearable};
-use multiversx_sc::types::{EgldOrEsdtTokenPayment, ReturnsHandledOrError};
+use multiversx_sc::types::ReturnsHandledOrError;
 use multiversx_sc::{
     imports::OptionalValue,
     types::{ManagedBuffer, MultiEgldOrEsdtPayment, MultiValueEncoded},

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -732,7 +732,7 @@ fn test_change_validator_set() {
 /// ### EXPECTED
 /// Error INVALID_EPOCH is emitted
 #[test]
-fn test_change_validator_set_genesis_not_set() {
+fn test_change_validator_invalid_epoch() {
     let mut state = HeaderVerifierTestState::new();
 
     state

--- a/header-verifier/tests/header_verifier_blackbox_tests.rs
+++ b/header-verifier/tests/header_verifier_blackbox_tests.rs
@@ -6,7 +6,7 @@ use common_test_setup::constants::{
 use error_messages::{
     CALLER_NOT_FROM_CURRENT_SOVEREIGN, CHAIN_CONFIG_SETUP_PHASE_NOT_COMPLETE,
     CURRENT_OPERATION_ALREADY_IN_EXECUTION, CURRENT_OPERATION_NOT_REGISTERED,
-    GENESIS_VALIDATORS_NOT_SET, INCORRECT_OPERATION_NONCE, OUTGOING_TX_HASH_ALREADY_REGISTERED,
+    INCORRECT_OPERATION_NONCE, INVALID_EPOCH, OUTGOING_TX_HASH_ALREADY_REGISTERED,
     SETUP_PHASE_NOT_COMPLETED,
 };
 use header_verifier::header_utils::HeaderVerifierUtilsModule;
@@ -727,10 +727,10 @@ fn test_change_validator_set() {
 /// H-VERIFIER_CHANGE_VALIDATORS_FAIL
 ///
 /// ### ACTION
-/// Call 'change_validator_set()' without registering the genesis validators
+/// Call 'change_validator_set()' for the genesis epoch
 ///
 /// ### EXPECTED
-/// Error GENESIS_VALIDATORS_NOT_SET is emitted
+/// Error INVALID_EPOCH is emitted
 #[test]
 fn test_change_validator_set_genesis_not_set() {
     let mut state = HeaderVerifierTestState::new();
@@ -760,17 +760,7 @@ fn test_change_validator_set_genesis_not_set() {
 
     let bitmap = ManagedBuffer::new_from_bytes(&[0x01]);
     let validator_set = MultiValueEncoded::new();
-    let epoch = 1u64;
-
-    state
-        .common_setup
-        .world
-        .tx()
-        .from(OWNER_ADDRESS)
-        .to(HEADER_VERIFIER_ADDRESS)
-        .whitebox(header_verifier::contract_obj, |sc| {
-            sc.bls_pub_keys(0).clear();
-        });
+    let epoch = 0u64;
 
     state.change_validator_set(
         &signature,
@@ -780,7 +770,7 @@ fn test_change_validator_set_genesis_not_set() {
         &bitmap,
         validator_set,
         Some(EXECUTED_BRIDGE_OP_EVENT),
-        Some(GENESIS_VALIDATORS_NOT_SET),
+        Some(INVALID_EPOCH),
     );
 }
 

--- a/interactor/src/complete_flows/complete_flows_interactor_main.rs
+++ b/interactor/src/complete_flows/complete_flows_interactor_main.rs
@@ -12,11 +12,13 @@ use common_test_setup::constants::{
     TOKEN_TICKER,
 };
 use cross_chain::DEFAULT_ISSUE_COST;
+use error_messages::{EXPECTED_MAPPED_TOKEN, FAILED_TO_REGISTER_SOVEREIGN_TOKEN};
 use multiversx_sc::chain_core::EGLD_000000_TOKEN_IDENTIFIER;
 use multiversx_sc_snippets::imports::*;
 use multiversx_sc_snippets::multiversx_sc_scenario::multiversx_chain_vm::crypto_functions::sha256;
 use structs::aliases::PaymentsVec;
 use structs::fee::FeeStruct;
+use structs::generate_hash::GenerateHash;
 use structs::operation::OperationData;
 use structs::{OperationHashStatus, RegisterTokenOperation};
 
@@ -252,28 +254,36 @@ impl CompleteFlowInteract {
         let nonce = self
             .common_state()
             .get_and_increment_operation_nonce(&mvx_esdt_safe_address.to_string());
-        self.register_token(
-            shard,
-            RegisterTokenOperation {
-                token_id: token.token_id.clone(),
-                token_type: token.token_type,
-                token_display_name: ManagedBuffer::from(TOKEN_DISPLAY_NAME),
-                token_ticker: ManagedBuffer::from(
-                    token
-                        .token_id
-                        .into_managed_buffer()
-                        .to_string()
-                        .split('-')
-                        .nth(1)
-                        .unwrap_or(TOKEN_TICKER),
-                ),
-                num_decimals: token.decimals,
-                data: OperationData::new(nonce, self.user_address().into(), None),
-            },
-            None,
-        )
-        .await
-        .expect("Failed to register sovereign token")
+
+        let operation = RegisterTokenOperation {
+            token_id: token.token_id.clone(),
+            token_type: token.token_type,
+            token_display_name: ManagedBuffer::from(TOKEN_DISPLAY_NAME),
+            token_ticker: ManagedBuffer::from(
+                token
+                    .token_id
+                    .into_managed_buffer()
+                    .to_string()
+                    .split('-')
+                    .nth(1)
+                    .unwrap_or(TOKEN_TICKER),
+            ),
+            num_decimals: token.decimals,
+            data: OperationData::new(nonce, self.user_address().into(), None),
+        };
+
+        let operation_hash = operation.generate_hash();
+        let hash_of_hashes = ManagedBuffer::new_from_bytes(&sha256(&operation_hash.to_vec()));
+
+        let operations_hashes =
+            MultiValueEncoded::from(ManagedVec::from(vec![operation_hash.clone()]));
+
+        self.register_operation(shard, &hash_of_hashes, operations_hashes)
+            .await;
+
+        self.register_token(shard, operation, None)
+            .await
+            .expect(FAILED_TO_REGISTER_SOVEREIGN_TOKEN)
     }
 
     pub async fn register_and_execute_sovereign_token(
@@ -303,7 +313,7 @@ impl CompleteFlowInteract {
 
         self.execute_wrapper(config, Some(token.clone()))
             .await
-            .expect("Expected mapped token, got None")
+            .expect(EXPECTED_MAPPED_TOKEN)
     }
 
     pub async fn update_fee_market_balance_state(

--- a/interactor/src/complete_flows/complete_flows_interactor_main.rs
+++ b/interactor/src/complete_flows/complete_flows_interactor_main.rs
@@ -248,6 +248,10 @@ impl CompleteFlowInteract {
     }
 
     async fn register_sovereign_token(&mut self, shard: u32, token: EsdtTokenInfo) -> String {
+        let mvx_esdt_safe_address = self.common_state().get_mvx_esdt_safe_address(shard).clone();
+        let nonce = self
+            .common_state()
+            .get_and_increment_operation_nonce(&mvx_esdt_safe_address.to_string());
         self.register_token(
             shard,
             RegisterTokenOperation {
@@ -264,7 +268,7 @@ impl CompleteFlowInteract {
                         .unwrap_or(TOKEN_TICKER),
                 ),
                 num_decimals: token.decimals,
-                data: OperationData::new(0u64, self.user_address().into(), None),
+                data: OperationData::new(nonce, self.user_address().into(), None),
             },
             None,
         )

--- a/mvx-esdt-safe/src/execute.rs
+++ b/mvx-esdt-safe/src/execute.rs
@@ -347,7 +347,7 @@ pub trait ExecuteModule:
         }
 
         let sc_address = self.blockchain().get_sc_address();
-        let tx_nonce = self.get_and_save_next_tx_id();
+        let tx_nonce = self.get_current_and_increment_tx_nonce();
         self.deposit_event(
             &operation.data.op_sender,
             &operation.map_tokens_to_multi_value_encoded(),

--- a/mvx-esdt-safe/src/register_token.rs
+++ b/mvx-esdt-safe/src/register_token.rs
@@ -36,6 +36,7 @@ pub trait RegisterTokenModule:
                 &token_hash,
                 Some(ERROR_AT_GENERATING_OPERATION_HASH.into()),
             );
+
             return;
         };
 
@@ -55,6 +56,7 @@ pub trait RegisterTokenModule:
                 &token_hash,
                 Some(SETUP_PHASE_NOT_COMPLETED.into()),
             );
+
             return;
         }
 
@@ -64,6 +66,8 @@ pub trait RegisterTokenModule:
             register_token_operation.data.op_nonce,
         ) {
             self.complete_operation(&hash_of_hashes, &token_hash, Some(lock_operation_error));
+
+            return;
         };
 
         let contract_balance = self
@@ -76,6 +80,7 @@ pub trait RegisterTokenModule:
                 &token_hash,
                 Some(NOT_ENOUGH_EGLD_FOR_REGISTER.into()),
             );
+
             return;
         }
 

--- a/sov-esdt-safe/src/lib.rs
+++ b/sov-esdt-safe/src/lib.rs
@@ -79,7 +79,7 @@ pub trait SovEsdtSafe:
             token_ticker,
             token_decimals,
             OperationData {
-                op_nonce: self.get_and_save_next_tx_id(),
+                op_nonce: self.get_current_and_increment_tx_nonce(),
                 op_sender: self.blockchain().get_caller(),
                 opt_transfer_data: None,
             },


### PR DESCRIPTION
Tightened fee-market initialization so invalid presets now panic instead of silently applying. Guarded Header-Verifier epoch rotation (including epoch 0) and added matching scenario coverage while fixing the missing return in `register_token`. Cleaned up stray imports and refreshed diagnostics.